### PR TITLE
Add privacy policy page

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -644,6 +644,19 @@ async def help_page(request: Request):
 
 
 # =============================================================================
+# Privacy Policy
+# =============================================================================
+
+@app.get("/budget/privacy", response_class=HTMLResponse)
+async def privacy_page(request: Request):
+    """Privacy policy page - accessible without login."""
+    return templates.TemplateResponse(
+        "privacy.html",
+        {"request": request, "show_nav": False}
+    )
+
+
+# =============================================================================
 # Public API (for uptime dashboard)
 # =============================================================================
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -60,6 +60,11 @@
                 <span class="text-xs mt-1">Hjælp</span>
             </a>
         </div>
+        <div class="max-w-md mx-auto text-center mt-1">
+            <a href="/budget/privacy" class="text-gray-400 dark:text-gray-500 text-xs hover:text-gray-600 dark:hover:text-gray-300">
+                Privatlivspolitik
+            </a>
+        </div>
     </nav>
     {% endif %}
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -64,6 +64,12 @@
                 </a>
             </p>
         </div>
+
+        <div class="mt-8 text-center">
+            <a href="/budget/privacy" class="text-gray-400 dark:text-gray-500 text-xs hover:text-gray-600 dark:hover:text-gray-300">
+                Privatlivspolitik
+            </a>
+        </div>
     </div>
 </div>
 {% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,143 @@
+{% extends "base.html" %}
+{% set show_nav = false %}
+
+{% block title %}Privatlivspolitik - Budget{% endblock %}
+
+{% block content %}
+<div class="max-w-lg mx-auto px-4 py-6">
+    <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Privatlivspolitik</h1>
+        <a href="/budget/login" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+            <i data-lucide="x" class="w-6 h-6"></i>
+        </a>
+    </div>
+
+    <div class="space-y-6">
+        <!-- Overblik -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="shield" class="w-5 h-5 mr-2 text-primary"></i>
+                Overblik
+            </h2>
+            <p class="text-gray-600 dark:text-gray-300 text-sm">
+                Family Budget er en simpel budget-app til privat brug. Vi indsamler kun de data,
+                du selv indtaster, og deler aldrig dine oplysninger med tredjeparter.
+            </p>
+        </section>
+
+        <!-- Hvilke data -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="database" class="w-5 h-5 mr-2 text-success"></i>
+                Hvilke data gemmer vi?
+            </h2>
+            <ul class="text-gray-600 dark:text-gray-300 text-sm space-y-2">
+                <li class="flex items-start">
+                    <i data-lucide="check" class="w-4 h-4 mr-2 mt-0.5 text-success flex-shrink-0"></i>
+                    <span><strong>Brugernavn</strong> - til login</span>
+                </li>
+                <li class="flex items-start">
+                    <i data-lucide="check" class="w-4 h-4 mr-2 mt-0.5 text-success flex-shrink-0"></i>
+                    <span><strong>Adgangskode</strong> - krypteret (kan ikke aflæses)</span>
+                </li>
+                <li class="flex items-start">
+                    <i data-lucide="check" class="w-4 h-4 mr-2 mt-0.5 text-success flex-shrink-0"></i>
+                    <span><strong>Email</strong> - kun hvis du selv tilføjer den (til password reset)</span>
+                </li>
+                <li class="flex items-start">
+                    <i data-lucide="check" class="w-4 h-4 mr-2 mt-0.5 text-success flex-shrink-0"></i>
+                    <span><strong>Budget-data</strong> - indkomst og udgifter du indtaster</span>
+                </li>
+            </ul>
+        </section>
+
+        <!-- Formål -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="target" class="w-5 h-5 mr-2 text-amber-500"></i>
+                Hvad bruger vi data til?
+            </h2>
+            <ul class="text-gray-600 dark:text-gray-300 text-sm space-y-2">
+                <li>At holde dig logget ind (session cookie)</li>
+                <li>At vise dit budget-overblik</li>
+                <li>At sende password-reset emails (hvis du har tilføjet email)</li>
+            </ul>
+            <p class="text-gray-500 dark:text-gray-400 text-xs mt-3">
+                Vi sælger, deler eller videregiver aldrig dine data til tredjeparter.
+            </p>
+        </section>
+
+        <!-- Cookies -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="cookie" class="w-5 h-5 mr-2 text-purple-500"></i>
+                Cookies
+            </h2>
+            <p class="text-gray-600 dark:text-gray-300 text-sm mb-2">
+                Vi bruger kun en enkelt session-cookie til at holde dig logget ind.
+            </p>
+            <div class="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-xs">
+                <ul class="text-gray-600 dark:text-gray-300 space-y-1">
+                    <li><strong>Navn:</strong> budget_session</li>
+                    <li><strong>Formål:</strong> Authentication</li>
+                    <li><strong>Varighed:</strong> 30 dage (slettes ved logout)</li>
+                </ul>
+            </div>
+            <p class="text-gray-500 dark:text-gray-400 text-xs mt-3">
+                Vi bruger ingen tracking, analytics eller marketing cookies.
+            </p>
+        </section>
+
+        <!-- Sikkerhed -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="lock" class="w-5 h-5 mr-2 text-danger"></i>
+                Sikkerhed
+            </h2>
+            <ul class="text-gray-600 dark:text-gray-300 text-sm space-y-1">
+                <li>Adgangskoder krypteres med PBKDF2 (100.000 iterationer)</li>
+                <li>Al kommunikation sker over HTTPS</li>
+                <li>Data gemmes lokalt på serveren (ikke i cloud)</li>
+            </ul>
+        </section>
+
+        <!-- Dine rettigheder -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="user-check" class="w-5 h-5 mr-2 text-primary"></i>
+                Dine rettigheder
+            </h2>
+            <p class="text-gray-600 dark:text-gray-300 text-sm mb-2">
+                Du har ret til at:
+            </p>
+            <ul class="text-gray-600 dark:text-gray-300 text-sm space-y-1">
+                <li>Se hvilke data vi har om dig</li>
+                <li>Rette dine oplysninger</li>
+                <li>Få slettet din konto og alle data</li>
+            </ul>
+            <p class="text-gray-500 dark:text-gray-400 text-xs mt-3">
+                Kontakt os hvis du vil udnytte disse rettigheder.
+            </p>
+        </section>
+
+        <!-- Kontakt -->
+        <section class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4">
+            <h2 class="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-3 flex items-center">
+                <i data-lucide="mail" class="w-5 h-5 mr-2"></i>
+                Kontakt
+            </h2>
+            <p class="text-blue-800 dark:text-blue-200 text-sm">
+                Spørgsmål om dine data? Kontakt os på:
+            </p>
+            <p class="text-blue-900 dark:text-blue-100 text-sm font-medium mt-1">
+                support@wibholmsolutions.com
+            </p>
+        </section>
+
+        <!-- Sidst opdateret -->
+        <p class="text-center text-gray-400 dark:text-gray-500 text-xs">
+            Sidst opdateret: Januar 2026
+        </p>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,6 +175,33 @@ class TestProtectedEndpoints:
         assert response.status_code == 303
 
 
+class TestPrivacyPolicy:
+    """Tests for privacy policy page."""
+
+    def test_privacy_accessible_without_auth(self, client):
+        """Privacy page should be accessible without authentication."""
+        response = client.get("/budget/privacy")
+
+        assert response.status_code == 200
+
+    def test_privacy_contains_required_sections(self, client):
+        """Privacy page should contain required GDPR information."""
+        response = client.get("/budget/privacy")
+
+        # Required sections for GDPR compliance
+        assert "privatlivspolitik" in response.text.lower()
+        assert "data" in response.text.lower()
+        assert "cookies" in response.text.lower()
+        assert "rettigheder" in response.text.lower()
+        assert "kontakt" in response.text.lower()
+
+    def test_privacy_accessible_when_authenticated(self, authenticated_client):
+        """Privacy page should also be accessible when logged in."""
+        response = authenticated_client.get("/budget/privacy")
+
+        assert response.status_code == 200
+
+
 class TestDashboard:
     """Tests for dashboard functionality."""
 


### PR DESCRIPTION
## Summary

- Add `/budget/privacy` endpoint accessible without login (GDPR requirement)
- Add privacy policy page with required sections for GDPR compliance
- Add link to privacy policy in login page and navigation footer

## Details

Privacy page includes:
- Overview of data practices
- What data is collected (username, password, email, budget data)
- Purpose of data collection
- Cookie information (session cookie only, no tracking)
- Security measures (PBKDF2, HTTPS)
- User rights (access, correction, deletion)
- Contact information

## Test plan

- [x] Privacy page accessible without authentication
- [x] Privacy page contains required GDPR sections
- [x] Privacy page accessible when logged in
- [x] All 73 tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)