### PR TITLE
feat: implement git-based dynamic versioning

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,18 +1,56 @@
 """Family Budget App package metadata."""
 
 import os
+import subprocess
 from pathlib import Path
 
 
+def _get_git_version() -> str | None:
+    """Get version from git tags or commit hash."""
+    try:
+        # Try to get the latest git tag
+        tag = subprocess.check_output(
+            ["git", "describe", "--tags", "--abbrev=0"],
+            stderr=subprocess.DEVNULL,
+            cwd=Path(__file__).resolve().parent.parent,
+        ).decode().strip()
+        # Remove 'v' prefix if present (v1.0.0 -> 1.0.0)
+        return tag.lstrip("v")
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    try:
+        # Fallback to short commit hash
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            cwd=Path(__file__).resolve().parent.parent,
+        ).decode().strip()
+        return f"dev-{commit}"
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    return None
+
+
 def _read_version() -> str:
+    """Read version from environment, git, or VERSION file."""
+    # 1. Check environment variable (highest priority)
     env_version = os.environ.get("APP_VERSION")
     if env_version:
         return env_version.strip()
+
+    # 2. Try git-based version
+    git_version = _get_git_version()
+    if git_version:
+        return git_version
+
+    # 3. Fallback to VERSION file
     version_file = Path(__file__).resolve().parent.parent / "VERSION"
     try:
         return version_file.read_text(encoding="utf-8").strip()
     except OSError:
-        return "0.0.0"
+        return "unknown"
 
 
 __version__ = _read_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,97 @@
+"""Unit tests for version functionality."""
+
+import importlib
+import os
+import re
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+# Import the module for testing internal functions
+import src as src_module
+
+
+class TestVersionFunctions:
+    """Tests for version reading functions."""
+
+    def test_get_version_returns_string(self):
+        """get_version() should return a string."""
+        from src import __version__
+
+        assert isinstance(__version__, str)
+
+    def test_get_version_not_empty(self):
+        """Version must not be empty."""
+        from src import __version__
+
+        assert __version__ != ""
+
+    def test_get_version_format(self):
+        """Version should match expected formats: X.Y.Z, dev-XXXXXX, or unknown."""
+        from src import __version__
+
+        # Valid patterns: semantic version, dev-hash, or unknown
+        semver_pattern = r"^\d+\.\d+\.\d+$"
+        dev_pattern = r"^dev-[a-f0-9]+$"
+        unknown_pattern = r"^unknown$"
+
+        is_valid = (
+            re.match(semver_pattern, __version__)
+            or re.match(dev_pattern, __version__)
+            or re.match(unknown_pattern, __version__)
+        )
+        assert is_valid, f"Version '{__version__}' does not match expected format"
+
+    def test_env_version_takes_priority(self):
+        """APP_VERSION environment variable should take highest priority."""
+        with patch.dict(os.environ, {"APP_VERSION": "99.88.77"}):
+            result = src_module._read_version()
+            assert result == "99.88.77"
+
+    def test_env_version_strips_whitespace(self):
+        """APP_VERSION should be stripped of whitespace."""
+        with patch.dict(os.environ, {"APP_VERSION": "  1.2.3  \n"}):
+            result = src_module._read_version()
+            assert result == "1.2.3"
+
+    def test_git_version_strips_v_prefix(self):
+        """Git tags with 'v' prefix should have it removed."""
+        # Mock git describe to return a v-prefixed tag
+        with patch("src.subprocess.check_output") as mock_git:
+            mock_git.return_value = b"v2.0.0\n"
+            result = src_module._get_git_version()
+            assert result == "2.0.0"
+
+    def test_git_fallback_to_commit_hash(self):
+        """Should fall back to commit hash if no tags exist."""
+        def mock_check_output(cmd, **kwargs):
+            if "describe" in cmd:
+                raise subprocess.CalledProcessError(128, cmd)
+            elif "rev-parse" in cmd:
+                return b"abc1234\n"
+            raise ValueError(f"Unexpected command: {cmd}")
+
+        with patch("src.subprocess.check_output", side_effect=mock_check_output):
+            result = src_module._get_git_version()
+            assert result == "dev-abc1234"
+
+    def test_git_version_returns_none_without_git(self):
+        """Should return None if git is not available."""
+        with patch("src.subprocess.check_output", side_effect=FileNotFoundError):
+            result = src_module._get_git_version()
+            assert result is None
+
+
+class TestVersionIntegration:
+    """Integration tests for version display."""
+
+    def test_help_page_shows_version(self, authenticated_client):
+        """Help page should display the current version."""
+        from src import __version__
+
+        response = authenticated_client.get("/budget/help")
+        assert response.status_code == 200
+        assert __version__ in response.text


### PR DESCRIPTION
## Summary

- Implement automatic version reading from git tags/commits
- Version is now determined from (in priority order):
  1. `APP_VERSION` environment variable
  2. Git tags (v-prefix stripped: `v1.0.0` → `1.0.0`)
  3. Git commit hash (as `dev-abc1234`)
  4. VERSION file fallback
  5. `"unknown"` if nothing available
- Add comprehensive unit tests for version functionality

Closes #29

## Release Workflow

After merging, create releases with:
```bash
git tag v1.2.3
git push --tags
```

## Test plan

- [x] `test_get_version_returns_string` - Version is a string
- [x] `test_get_version_not_empty` - Version is not empty
- [x] `test_get_version_format` - Matches expected format (X.Y.Z, dev-XXX, or unknown)
- [x] `test_env_version_takes_priority` - APP_VERSION env var has highest priority
- [x] `test_git_version_strips_v_prefix` - v-prefix removed from tags
- [x] `test_git_fallback_to_commit_hash` - Falls back to commit hash
- [x] `test_git_version_returns_none_without_git` - Handles missing git
- [x] `test_help_page_shows_version` - Version displayed in UI
- [x] All 93 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)