### PR TITLE
feat: add frequency help tooltip to expenses and income pages

### DIFF
--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -185,7 +185,20 @@
             </div>
 
             <div>
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Frekvens</label>
+                <div class="flex items-center gap-2 mb-2">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Frekvens</label>
+                    <div class="relative group">
+                        <i data-lucide="help-circle" class="w-4 h-4 text-gray-400 cursor-help"></i>
+                        <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50">
+                            <div class="font-medium mb-1">Beløb omregnes til månedlig:</div>
+                            <div>Månedlig = beløb pr. måned</div>
+                            <div>Kvartalsvis = beløb ÷ 3</div>
+                            <div>Halvårlig = beløb ÷ 6</div>
+                            <div>Årlig = beløb ÷ 12</div>
+                            <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+                        </div>
+                    </div>
+                </div>
                 <div class="grid grid-cols-2 gap-2">
                     <label>
                         <input type="radio" name="frequency" value="monthly" class="sr-only peer" checked>

--- a/templates/income.html
+++ b/templates/income.html
@@ -61,7 +61,20 @@
                         </div>
                     </label>
                     <label class="block">
-                        <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                        <div class="flex items-center gap-1">
+                            <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                            <div class="relative group">
+                                <i data-lucide="help-circle" class="w-3.5 h-3.5 text-gray-400 cursor-help"></i>
+                                <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50">
+                                    <div class="font-medium mb-1">Beløb omregnes til månedlig:</div>
+                                    <div>Månedlig = beløb pr. måned</div>
+                                    <div>Kvartalsvis = beløb ÷ 3</div>
+                                    <div>Halvårlig = beløb ÷ 6</div>
+                                    <div>Årlig = beløb ÷ 12</div>
+                                    <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+                                </div>
+                            </div>
+                        </div>
                         <select
                             name="income_frequency_{{ loop.index0 }}"
                             class="w-full mt-1 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
@@ -157,7 +170,20 @@
                         </div>
                     </label>
                     <label class="block">
-                        <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                        <div class="flex items-center gap-1">
+                            <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                            <div class="relative group">
+                                <i data-lucide="help-circle" class="w-3.5 h-3.5 text-gray-400 cursor-help"></i>
+                                <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50">
+                                    <div class="font-medium mb-1">Beløb omregnes til månedlig:</div>
+                                    <div>Månedlig = beløb pr. måned</div>
+                                    <div>Kvartalsvis = beløb ÷ 3</div>
+                                    <div>Halvårlig = beløb ÷ 6</div>
+                                    <div>Årlig = beløb ÷ 12</div>
+                                    <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+                                </div>
+                            </div>
+                        </div>
                         <select
                             name="income_frequency_${incomeIndex}"
                             class="w-full mt-1 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"


### PR DESCRIPTION
## Summary

- Add hover tooltip with help icon next to "Frekvens" label
- Explains how amounts are converted to monthly for budget calculations:
  - Månedlig = beløb pr. måned
  - Kvartalsvis = beløb ÷ 3
  - Halvårlig = beløb ÷ 6
  - Årlig = beløb ÷ 12
- Applied to both existing items and dynamically added items

Closes #20

## Changes

- `templates/expenses.html` - Add tooltip to expense frequency selector
- `templates/income.html` - Add tooltip to income frequency selector (both existing and new items)

## Test plan

- [x] All 84 unit tests pass
- [ ] Manual: Hover over help icon on expenses page shows tooltip
- [ ] Manual: Hover over help icon on income page shows tooltip
- [ ] Manual: New income items also show the help tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)