### PR TITLE
feat: GitHub link i hjælp-menuen

### DIFF
--- a/templates/help.html
+++ b/templates/help.html
@@ -156,6 +156,20 @@
                 </p>
             </div>
         </section>
+
+        <!-- GitHub link -->
+        <section class="bg-gray-50 dark:bg-gray-800 rounded-xl p-4">
+            <a href="https://github.com/saabendtsen/family-budget" target="_blank" rel="noopener noreferrer" class="flex items-center justify-between text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors">
+                <div class="flex items-center">
+                    <i data-lucide="github" class="w-5 h-5 mr-3"></i>
+                    <div>
+                        <div class="font-medium">Se kildekode på GitHub</div>
+                        <div class="text-xs text-gray-500 dark:text-gray-400">Rapporter fejl eller foreslå forbedringer</div>
+                    </div>
+                </div>
+                <i data-lucide="external-link" class="w-4 h-4"></i>
+            </a>
+        </section>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Tilføjer link til GitHub repository nederst på hjælp-siden
- Viser "Se kildekode på GitHub" med beskrivelse om at rapportere fejl

## Changes
- `templates/help.html`: Tilføjet GitHub link sektion med github og external-link ikoner

## Test plan
- [ ] Åbn hjælp-siden
- [ ] Verificer GitHub link vises nederst
- [ ] Klik på linket og verificer det åbner GitHub i ny fane
- [ ] Test i dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #48