### PR TITLE
feat: Opret CI/CD pipeline til automatisk deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
+
+    steps:
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            cd ~/projects/family-budget
+            git pull origin master
+            source venv/bin/activate
+            pip install -r requirements.txt --quiet
+            systemctl --user restart family-budget
+            echo "Deployed successfully at $(date)"


### PR DESCRIPTION
## Summary
- Tilføjer deployment workflow til automatisk deploy ved push til master
- Bruger SSH til at deploye til produktionsserver
- Kan også køres manuelt via GitHub Actions UI

## Required GitHub Secrets
For at aktivere deployment, tilføj følgende secrets i repository settings:
- `DEPLOY_HOST`: Server hostname eller IP
- `DEPLOY_USER`: SSH brugernavn
- `DEPLOY_SSH_KEY`: Privat SSH nøgle

## Changes
- `.github/workflows/deploy.yml`: Ny deployment workflow

## Test plan
- [ ] Verificer workflow filen er syntaktisk korrekt (GitHub Actions UI)
- [ ] Konfigurer secrets i repository
- [ ] Test manual dispatch
- [ ] Verificer automatisk deploy ved merge til master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #52