### PR TITLE
feat: Add frequency tooltip explaining monthly calculations

### DIFF
--- a/templates/expenses.html
+++ b/templates/expenses.html
@@ -185,7 +185,23 @@
             </div>
 
             <div>
-                <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Frekvens</label>
+                <div class="flex items-center gap-1 mb-2">
+                    <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">Frekvens</label>
+                    <div class="relative group">
+                        <button type="button" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" onclick="event.preventDefault()">
+                            <i data-lucide="help-circle" class="w-4 h-4"></i>
+                        </button>
+                        <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50 shadow-lg">
+                            <div class="space-y-1">
+                                <div><strong>Månedlig:</strong> Betales hver måned</div>
+                                <div><strong>Kvartalsvis:</strong> Betales hver 3. måned (÷3)</div>
+                                <div><strong>Halvårlig:</strong> Betales hver 6. måned (÷6)</div>
+                                <div><strong>Årlig:</strong> Betales 1 gang om året (÷12)</div>
+                            </div>
+                            <div class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></div>
+                        </div>
+                    </div>
+                </div>
                 <div class="grid grid-cols-2 gap-2">
                     <label>
                         <input type="radio" name="frequency" value="monthly" class="sr-only peer" checked>

--- a/templates/income.html
+++ b/templates/income.html
@@ -61,7 +61,21 @@
                         </div>
                     </label>
                     <label class="block">
-                        <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                        <span class="text-gray-500 dark:text-gray-400 text-sm flex items-center gap-1">
+                            Frekvens
+                            <span class="relative group">
+                                <i data-lucide="help-circle" class="w-3.5 h-3.5 cursor-help"></i>
+                                <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50 shadow-lg">
+                                    <span class="block space-y-1">
+                                        <span class="block"><strong>Månedlig:</strong> Hver måned</span>
+                                        <span class="block"><strong>Kvartalsvis:</strong> Hver 3. md (÷3)</span>
+                                        <span class="block"><strong>Halvårlig:</strong> Hver 6. md (÷6)</span>
+                                        <span class="block"><strong>Årlig:</strong> 1 gang/år (÷12)</span>
+                                    </span>
+                                    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></span>
+                                </span>
+                            </span>
+                        </span>
                         <select
                             name="income_frequency_{{ loop.index0 }}"
                             class="w-full mt-1 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
@@ -157,7 +171,21 @@
                         </div>
                     </label>
                     <label class="block">
-                        <span class="text-gray-500 dark:text-gray-400 text-sm">Frekvens</span>
+                        <span class="text-gray-500 dark:text-gray-400 text-sm flex items-center gap-1">
+                            Frekvens
+                            <span class="relative group">
+                                <i data-lucide="help-circle" class="w-3.5 h-3.5 cursor-help"></i>
+                                <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900 dark:bg-gray-700 text-white text-xs rounded-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all duration-200 whitespace-nowrap z-50 shadow-lg">
+                                    <span class="block space-y-1">
+                                        <span class="block"><strong>Månedlig:</strong> Hver måned</span>
+                                        <span class="block"><strong>Kvartalsvis:</strong> Hver 3. md (÷3)</span>
+                                        <span class="block"><strong>Halvårlig:</strong> Hver 6. md (÷6)</span>
+                                        <span class="block"><strong>Årlig:</strong> 1 gang/år (÷12)</span>
+                                    </span>
+                                    <span class="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700"></span>
+                                </span>
+                            </span>
+                        </span>
                         <select
                             name="income_frequency_${incomeIndex}"
                             class="w-full mt-1 px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"


### PR DESCRIPTION
## Summary
- Adds help icon with tooltip next to the "Frekvens" (frequency) selector
- Tooltip explains how each frequency is converted to a monthly amount

## Changes
- **expenses.html**: Added tooltip next to frequency radio buttons
- **income.html**: Added tooltip next to frequency dropdown (both in Jinja template and JS template)

## Tooltip content
| Frequency | Explanation |
|-----------|-------------|
| Månedlig | Betales hver måned |
| Kvartalsvis | Betales hver 3. måned (÷3) |
| Halvårlig | Betales hver 6. måned (÷6) |
| Årlig | Betales 1 gang om året (÷12) |

## Test plan
- [x] All 86 tests pass
- [x] Tooltip appears on hover on both expenses and income pages
- [x] Works in dark mode
- [x] Works on dynamically added income fields

Fixes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)