### PR TITLE
feat: Add feedback function with GitHub issue integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@ uvicorn>=0.24.0
 jinja2>=3.1.0
 python-multipart>=0.0.6
 python-dotenv>=1.0.0
+httpx>=0.27.0
 
 # Testing
 pytest>=8.0.0
 pytest-asyncio>=0.23.0
-httpx>=0.27.0
 pytest-cov>=4.1.0
 
 # E2E Testing

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+{% set show_nav = true %}
+{% set active_page = 'help' %}
+
+{% block title %}Feedback - Budget{% endblock %}
+
+{% block content %}
+<div class="max-w-lg mx-auto px-4 py-6">
+    <div class="flex items-center justify-between mb-6">
+        <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Send feedback</h1>
+        <a href="/budget/help" class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200">
+            <i data-lucide="x" class="w-6 h-6"></i>
+        </a>
+    </div>
+
+    {% if success %}
+    <div class="bg-green-50 dark:bg-green-900/30 rounded-xl p-4 mb-6">
+        <div class="flex items-center gap-3">
+            <i data-lucide="check-circle" class="w-6 h-6 text-green-600 dark:text-green-400"></i>
+            <div>
+                <p class="font-medium text-green-800 dark:text-green-200">Tak for din feedback!</p>
+                <p class="text-sm text-green-700 dark:text-green-300 mt-1">Din besked er blevet sendt.</p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if error %}
+    <div class="bg-red-50 dark:bg-red-900/30 rounded-xl p-4 mb-6">
+        <div class="flex items-center gap-3">
+            <i data-lucide="alert-circle" class="w-6 h-6 text-red-600 dark:text-red-400"></i>
+            <div>
+                <p class="font-medium text-red-800 dark:text-red-200">Der opstod en fejl</p>
+                <p class="text-sm text-red-700 dark:text-red-300 mt-1">{{ error }}</p>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    {% if not success %}
+    <form method="post" action="/budget/feedback" class="space-y-4">
+        <!-- Type -->
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Type</label>
+            <select
+                name="feedback_type"
+                class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                required
+            >
+                <option value="feedback">Feedback</option>
+                <option value="feature">Feature request</option>
+                <option value="bug">Fejlrapport</option>
+            </select>
+        </div>
+
+        <!-- Description -->
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Besked</label>
+            <textarea
+                name="description"
+                rows="5"
+                placeholder="Beskriv din feedback, ide eller fejl..."
+                class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white resize-none"
+                required
+                minlength="10"
+            ></textarea>
+        </div>
+
+        <!-- Email (optional) -->
+        <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                Email (valgfrit)
+            </label>
+            <input
+                type="email"
+                name="email"
+                placeholder="din@email.dk"
+                class="w-full px-4 py-3 border border-gray-300 dark:border-gray-600 rounded-xl focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+            >
+            <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                <i data-lucide="info" class="w-3 h-3 inline"></i>
+                Vi kan ikke svare direkte. Angiv kun email hvis du vil kontaktes.
+            </p>
+        </div>
+
+        <!-- Honeypot field (spam protection) -->
+        <div class="hidden" aria-hidden="true">
+            <input type="text" name="website" tabindex="-1" autocomplete="off">
+        </div>
+
+        <button
+            type="submit"
+            class="w-full bg-primary text-white py-4 rounded-xl font-medium hover:bg-blue-600 active:bg-blue-700 transition-colors flex items-center justify-center gap-2"
+        >
+            <i data-lucide="send" class="w-5 h-5"></i>
+            Send feedback
+        </button>
+    </form>
+
+    <div class="mt-6 bg-gray-50 dark:bg-gray-800 rounded-xl p-4 text-sm text-gray-600 dark:text-gray-400">
+        <p class="flex items-center gap-2">
+            <i data-lucide="shield" class="w-4 h-4"></i>
+            Din feedback behandles anonymt med mindre du angiver email.
+        </p>
+    </div>
+    {% else %}
+    <a
+        href="/budget/help"
+        class="w-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 py-4 rounded-xl font-medium hover:bg-gray-200 dark:hover:bg-gray-600 transition-colors flex items-center justify-center gap-2"
+    >
+        <i data-lucide="arrow-left" class="w-5 h-5"></i>
+        Tilbage til hjælp
+    </a>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/help.html
+++ b/templates/help.html
@@ -120,6 +120,24 @@
             </ul>
         </section>
 
+        <!-- Feedback -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="message-square" class="w-5 h-5 mr-2 text-primary"></i>
+                Feedback
+            </h2>
+            <p class="text-gray-600 dark:text-gray-300 text-sm mb-3">
+                Har du forslag til forbedringer, fundet en fejl eller bare vil sige tak?
+            </p>
+            <a
+                href="/budget/feedback"
+                class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors"
+            >
+                <i data-lucide="send" class="w-4 h-4"></i>
+                Send feedback
+            </a>
+        </section>
+
         <!-- Om Budget -->
         <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">


### PR DESCRIPTION
## Summary
- Adds a feedback page accessible from the help menu
- Users can submit feedback, feature requests, or bug reports
- Optionally creates GitHub issues when GITHUB_TOKEN is configured

## Features
- **Three feedback types**: Feedback, Feature request, Bug report
- **Optional email**: Only if user wants to be contacted
- **Spam protection**:
  - Honeypot field to catch bots
  - Rate limiting (5 submissions per hour per IP)
- **GitHub integration**: Creates issues with appropriate labels when token is set

## Configuration
To enable GitHub issue creation, set these environment variables:
```bash
GITHUB_TOKEN=your_personal_access_token  # needs 'repo' scope
GITHUB_REPO=owner/repo  # defaults to saabendtsen/family-budget
```

## Test plan
- [x] All 93 tests pass
- [x] Feedback page loads for authenticated users
- [x] Requires authentication
- [x] Validates minimum description length
- [x] Honeypot silently rejects bots
- [x] Help page has feedback link

Fixes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)