### PR TITLE
feat(deploy): add automatic database backup before deploy

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -3,7 +3,37 @@
 # Checks for new commits on origin/main and deploys if found
 
 set -e
-cd ~/projects/family-budget
+
+PROJECT_DIR=~/projects/family-budget
+cd "$PROJECT_DIR"
+
+# Backup database before deploy to prevent data loss
+backup_database() {
+    local DATA_DIR="$PROJECT_DIR/data"
+    local DB_FILE="$DATA_DIR/budget.db"
+    local BACKUP_FILE="$DATA_DIR/budget.db.backup-$(date +%Y%m%d-%H%M%S)"
+    local MAX_BACKUPS=10
+
+    # Check if database exists
+    if [ ! -f "$DB_FILE" ]; then
+        echo "No database to backup"
+        return 0
+    fi
+
+    # Create backup
+    echo "Creating backup: $BACKUP_FILE"
+    cp "$DB_FILE" "$BACKUP_FILE" || {
+        echo "ERROR: Backup failed!"
+        return 1
+    }
+
+    # Cleanup old backups (keep last 10)
+    echo "Cleaning old backups (keeping last $MAX_BACKUPS)..."
+    ls -t "$DATA_DIR"/budget.db.backup-* 2>/dev/null | tail -n +$((MAX_BACKUPS + 1)) | xargs -r rm
+
+    echo "Backup complete"
+    return 0
+}
 
 BRANCH="main"
 if ! git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
@@ -28,6 +58,13 @@ echo "[$(date)] New commits detected, deploying..."
 git reset --hard "origin/$BRANCH"
 export APP_VERSION=$(cat VERSION)
 docker compose build --quiet --build-arg APP_VERSION="$APP_VERSION"
+
+# Backup database before taking down containers
+backup_database || {
+    echo "[$(date)] ❌ Backup failed - aborting deploy"
+    exit 1
+}
+
 docker compose down
 docker compose up -d
 


### PR DESCRIPTION
## Summary
- Adds automatic SQLite database backup before `docker compose down`
- Keeps last 10 backups, automatically cleans older ones
- Aborts deploy if backup fails to prevent data loss

## Test plan
- [ ] Trigger deploy manually and verify backup is created
- [ ] Check that old backups are cleaned up after 10+
- [ ] Verify deploy aborts if backup fails (e.g., readonly data dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)