### PR TITLE
refactor(email): simplify storage to hash-only, remove encryption

### DIFF
--- a/templates/forgot-password.html
+++ b/templates/forgot-password.html
@@ -38,7 +38,7 @@
 
             <div class="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-4 py-3 rounded-xl text-sm">
                 <i data-lucide="info" class="w-4 h-4 inline-block mr-1"></i>
-                Du skal have tilknyttet en email til din konto for at nulstille din adgangskode.
+                Indtast den email du tilknyttede din konto. Vi sender et link du kan bruge til at vælge en ny adgangskode.
             </div>
 
             {% if error %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -23,7 +23,7 @@
                     {% if has_email %}
                         <span class="text-green-600 dark:text-green-400">
                             <i data-lucide="mail-check" class="w-3 h-3 inline"></i>
-                            Email tilføjet (krypteret)
+                            Email tilføjet (privat)
                         </span>
                     {% else %}
                         <span class="text-gray-400">Ingen email</span>
@@ -54,9 +54,20 @@
                 <h2 class="font-medium text-gray-900 dark:text-white mb-1">
                     {% if has_email %}Opdater email{% else %}Tilføj email{% endif %}
                 </h2>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                    Bruges til at nulstille din adgangskode hvis du glemmer den.
-                </p>
+            </div>
+
+            <!-- Privacy info box -->
+            <div class="bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-3 py-3 rounded-lg text-sm">
+                <div class="flex items-start gap-2">
+                    <i data-lucide="shield-check" class="w-4 h-4 mt-0.5 flex-shrink-0"></i>
+                    <div>
+                        <p class="font-medium">Privat email-lagring</p>
+                        <p class="mt-1 text-xs opacity-90">
+                            Din email gemmes anonymt – vi kan ikke se den, og den kan ikke læses fra vores database.
+                            Den bruges kun til at verificere at det er dig, når du beder om at nulstille din adgangskode.
+                        </p>
+                    </div>
+                </div>
             </div>
 
             <div>
@@ -69,30 +80,6 @@
                 >
             </div>
 
-            <div id="pin-section" class="hidden space-y-3">
-                <div>
-                    <input
-                        type="text"
-                        name="email_pin"
-                        id="email_pin"
-                        placeholder="4-cifret kode"
-                        inputmode="numeric"
-                        pattern="[0-9]{4}"
-                        maxlength="4"
-                        class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
-                    >
-                </div>
-                <div class="bg-amber-50 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-3 py-2 rounded-lg text-xs">
-                    <div class="flex items-start gap-2">
-                        <i data-lucide="alert-triangle" class="w-3 h-3 mt-0.5 flex-shrink-0"></i>
-                        <div>
-                            <p class="font-medium">Gem koden sikkert!</p>
-                            <p class="mt-0.5">Vi gemmer IKKE koden. Uden den kan du ikke nulstille din adgangskode.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
             <button
                 type="submit"
                 class="w-full px-4 py-2 bg-primary text-white rounded-lg hover:bg-blue-600 transition-colors"
@@ -102,7 +89,7 @@
 
             {% if has_email %}
             <p class="text-xs text-gray-400 dark:text-gray-500 text-center">
-                Lad felterne være tomme og tryk gem for at fjerne email
+                Lad feltet være tomt og tryk gem for at fjerne email
             </p>
             {% endif %}
         </div>
@@ -120,25 +107,6 @@
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
-    const emailInput = document.getElementById('email');
-    const pinSection = document.getElementById('pin-section');
-    const pinInput = document.getElementById('email_pin');
-
-    function updatePinVisibility() {
-        const hasEmail = emailInput.value.trim().length > 0;
-        if (hasEmail) {
-            pinSection.classList.remove('hidden');
-            pinInput.required = true;
-        } else {
-            pinSection.classList.add('hidden');
-            pinInput.required = false;
-            pinInput.value = '';
-        }
-    }
-
-    emailInput.addEventListener('input', updatePinVisibility);
-    updatePinVisibility();
-
     if (typeof lucide !== 'undefined') {
         lucide.createIcons();
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,7 +177,7 @@ class TestPasswordReset:
     def test_forgot_password_creates_token_for_valid_user(self, client, db_module):
         """Forgot password should create token for user with email."""
         user_id = db_module.create_user("resetuser1", "oldpass")
-        db_module.update_user_email(user_id, "reset@example.com", "1234")
+        db_module.update_user_email(user_id, "reset@example.com")
 
         response = client.post(
             "/budget/forgot-password",


### PR DESCRIPTION
## Summary
- Remove PIN-based email encryption and keep only SHA-256 hash for password reset lookup
- Email is never stored - only its hash is kept for verification purposes
- Simplify code by removing ~170 lines of encryption logic

## Changes
- Remove `encrypt_email()`, `decrypt_email()` and `_derive_email_key()` functions
- Remove `cryptography` dependency usage from database.py
- Update `User` dataclass to only have `email_hash` field
- Simplify `update_user_email()` to store hash only
- Update settings page with privacy info-box explaining anonymous storage
- Remove PIN field from UI
- Add migration to drop `email_encrypted` and `email_salt` columns
- Update all tests to reflect simplified API

## User-facing changes
- Badge text changed from "krypteret" to "privat"
- Settings page now explains privacy-preserving storage
- Forgot password page text updated to be clearer

## Test plan
- [x] All 138 existing tests pass
- [ ] Manual test: Register new user with email
- [ ] Manual test: Use "glemt password" with the email
- [ ] Manual test: Receive reset-link and reset password
- [ ] Verify in database that only `email_hash` is stored

🤖 Generated with [Claude Code](https://claude.com/claude-code)