### PR TITLE
fix: gate deploy on CI status check

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -54,6 +54,18 @@ fi
 
 echo "[$(date)] New commits detected, deploying..."
 
+# Check CI status before deploying
+CI_STATUS=$(gh run list --repo saabendtsen/family-budget --workflow=ci.yml --branch="$BRANCH" --limit 1 \
+  --json conclusion,headSha \
+  --jq '.[0] | select(.headSha == "'"$REMOTE"'") | .conclusion')
+
+if [ "$CI_STATUS" != "success" ]; then
+    echo "[$(date)] ⏳ CI not yet successful for $(echo $REMOTE | cut -c1-7) (status: ${CI_STATUS:-pending})"
+    exit 0
+fi
+
+echo "[$(date)] ✅ CI passed, deploying..."
+
 # Pull and rebuild
 git reset --hard "origin/$BRANCH"
 export APP_VERSION=$(cat VERSION)


### PR DESCRIPTION
## Summary
- Add CI status check to `scripts/deploy.sh` — verifies the CI workflow passed for the exact commit SHA before deploying
- If CI is pending or failed, exits cleanly (`exit 0`) so the systemd timer retries next minute
- Also includes category rename feedback and test fix from earlier commits on this branch

## Test plan
- [x] `bash -n scripts/deploy.sh` passes
- [x] Verified `gh run list` returns `success` for latest `origin/master` commit
- [x] Confirmed `exit 0` on non-matching SHA (graceful retry)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)