### PR TITLE
feat: add donation buttons to help page

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -97,6 +97,13 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
 # Load environment
 load_dotenv(Path(__file__).parent.parent / ".env")
 
+# Stripe donation payment links (override with env vars for production)
+DONATION_LINKS = {
+    10: os.getenv("STRIPE_DONATE_10", "https://buy.stripe.com/test_28E14hdiw6eb5Z70Jl9IQ00"),
+    25: os.getenv("STRIPE_DONATE_25", "https://buy.stripe.com/test_aFa4gt3HW0TR0ENdw79IQ01"),
+    50: os.getenv("STRIPE_DONATE_50", "https://buy.stripe.com/test_5kQ6oB5Q40TRevDfEf9IQ02"),
+}
+
 
 # Session management (file-based for persistence)
 # Sessions map hashed tokens to user_ids
@@ -1048,9 +1055,14 @@ async def help_page(request: Request):
     if not check_auth(request):
         return RedirectResponse(url="/budget/login", status_code=303)
 
+    demo_mode = is_demo_mode(request)
     return templates.TemplateResponse(
         "help.html",
-        {"request": request, "demo_mode": is_demo_mode(request)}
+        {
+            "request": request,
+            "demo_mode": demo_mode,
+            "donation_links": DONATION_LINKS if not demo_mode else {},
+        }
     )
 
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -157,6 +157,32 @@
             </div>
         </section>
 
+        {% if donation_links %}
+        <!-- Støt projektet -->
+        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
+            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
+                <i data-lucide="heart" class="w-5 h-5 mr-2 text-red-500"></i>
+                Støt projektet
+            </h2>
+            <p class="text-gray-600 dark:text-gray-300 text-sm mb-4">
+                Kan du lide Budget? Hjælp med at holde projektet kørende ved at give en lille donation.
+            </p>
+            <div class="flex flex-wrap gap-3">
+                {% for amount, url in donation_links.items() %}
+                <a
+                    href="{{ url }}"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="inline-flex items-center gap-2 bg-primary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-blue-600 transition-colors"
+                >
+                    <i data-lucide="coffee" class="w-4 h-4"></i>
+                    {{ amount }} kr.
+                </a>
+                {% endfor %}
+            </div>
+        </section>
+        {% endif %}
+
         <!-- Privatlivspolitik -->
         <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -714,6 +714,23 @@ class TestFeedback:
         assert response.status_code == 200
         assert "/budget/feedback" in response.text
 
+    def test_help_page_shows_donation_section(self, authenticated_client):
+        """Help page should show donation buttons for authenticated users."""
+        response = authenticated_client.get("/budget/help")
+        assert response.status_code == 200
+        assert "Støt projektet" in response.text
+        assert "buy.stripe.com" in response.text
+        assert "10 kr." in response.text
+        assert "25 kr." in response.text
+        assert "50 kr." in response.text
+
+    def test_help_page_hides_donation_in_demo_mode(self, client):
+        """Help page should not show donation buttons in demo mode."""
+        client.get("/budget/demo")
+        response = client.get("/budget/help")
+        assert response.status_code == 200
+        assert "Støt projektet" not in response.text
+
 
 class TestRateLimiting:
     """Tests for rate limiting middleware."""


### PR DESCRIPTION
## Summary
- Adds "Støt projektet" section on the help page with 10, 25 and 50 kr donation buttons
- Buttons link to Stripe Payment Links (opens in new tab)
- Hidden in demo mode
- Payment link URLs configurable via `STRIPE_DONATE_10/25/50` env vars (defaults to test links)

## Stripe Setup (done in sandbox)
- 3 Payment Links created (10, 25, 50 kr DKK)
- MobilePay, Google Pay, Apple Pay enabled
- Amazon Pay, Link, Klarna disabled

## Test plan
- [x] All 78 tests pass (including 2 new tests)
- [ ] Verify help page shows donation buttons for logged-in users
- [ ] Verify demo mode hides donation section
- [ ] Verify buttons open Stripe Payment Links in new tab

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)