### PR TITLE
Ryd op på help page - fjern 5 sektioner

### DIFF
--- a/templates/help.html
+++ b/templates/help.html
@@ -28,42 +28,6 @@
             </ol>
         </section>
 
-        <!-- Indkomst -->
-        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
-                <i data-lucide="wallet" class="w-5 h-5 mr-2 text-success"></i>
-                Indkomst
-            </h2>
-            <p class="text-gray-600 dark:text-gray-300 text-sm mb-2">
-                Indtast den månedlige nettoløn (efter skat) for hver person i husstanden.
-            </p>
-            <p class="text-gray-500 dark:text-gray-400 text-xs">
-                Tip: Brug gennemsnittet hvis lønnen varierer fra måned til måned.
-            </p>
-        </section>
-
-        <!-- Udgifter -->
-        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
-                <i data-lucide="receipt" class="w-5 h-5 mr-2 text-danger"></i>
-                Udgifter
-            </h2>
-            <p class="text-gray-600 dark:text-gray-300 text-sm mb-3">
-                Tilføj alle dine faste udgifter. Du kan vælge om de betales månedligt eller årligt.
-            </p>
-            <div class="bg-gray-50 dark:bg-gray-700/50 rounded-lg p-3 text-sm">
-                <p class="font-medium text-gray-700 dark:text-gray-200 mb-2">Typiske udgifter at huske:</p>
-                <ul class="text-gray-600 dark:text-gray-300 space-y-1 text-xs">
-                    <li>• Husleje eller boliglån</li>
-                    <li>• El, vand, varme, internet</li>
-                    <li>• Forsikringer (indbo, bil, ulykke)</li>
-                    <li>• Transport (benzin, lån, afgifter)</li>
-                    <li>• Abonnementer (streaming, fitness)</li>
-                    <li>• Dagligvarer og mad</li>
-                </ul>
-            </div>
-        </section>
-
         <!-- Kategorier -->
         <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
             <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
@@ -74,50 +38,6 @@
                 Udgifter grupperes i kategorier så du nemt kan se, hvor pengene går hen.
                 Du kan oprette dine egne kategorier under "Udgifter".
             </p>
-        </section>
-
-        <!-- Overblik -->
-        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
-                <i data-lucide="pie-chart" class="w-5 h-5 mr-2 text-purple-500"></i>
-                Forstå overblikket
-            </h2>
-            <div class="space-y-3 text-sm">
-                <div class="flex items-start">
-                    <div class="w-3 h-3 rounded-full bg-success mt-1.5 mr-2 flex-shrink-0"></div>
-                    <div>
-                        <span class="font-medium text-gray-700 dark:text-gray-200">Til rådighed</span>
-                        <p class="text-gray-500 dark:text-gray-400 text-xs">Hvad der er tilbage efter alle faste udgifter</p>
-                    </div>
-                </div>
-                <div class="flex items-start">
-                    <div class="w-3 h-3 rounded-full bg-primary mt-1.5 mr-2 flex-shrink-0"></div>
-                    <div>
-                        <span class="font-medium text-gray-700 dark:text-gray-200">Indkomst</span>
-                        <p class="text-gray-500 dark:text-gray-400 text-xs">Samlet månedlig indtægt</p>
-                    </div>
-                </div>
-                <div class="flex items-start">
-                    <div class="w-3 h-3 rounded-full bg-danger mt-1.5 mr-2 flex-shrink-0"></div>
-                    <div>
-                        <span class="font-medium text-gray-700 dark:text-gray-200">Udgifter</span>
-                        <p class="text-gray-500 dark:text-gray-400 text-xs">Faste udgifter omregnet til månedligt beløb</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Tips -->
-        <section class="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-4">
-            <h2 class="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-3 flex items-center">
-                <i data-lucide="lightbulb" class="w-5 h-5 mr-2"></i>
-                Tips
-            </h2>
-            <ul class="text-blue-800 dark:text-blue-200 text-sm space-y-2">
-                <li>• Årlige udgifter (fx forsikring) vises som 1/12 per måned</li>
-                <li>• Husk opsparing som en "udgift" for at budgettere korrekt</li>
-                <li>• Tjek dit budget regelmæssigt og opdater ved ændringer</li>
-            </ul>
         </section>
 
         <!-- Feedback -->
@@ -136,25 +56,6 @@
                 <i data-lucide="send" class="w-4 h-4"></i>
                 Send feedback
             </a>
-        </section>
-
-        <!-- Om Budget -->
-        <section class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm">
-            <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center">
-                <i data-lucide="info" class="w-5 h-5 mr-2 text-gray-500"></i>
-                Om Budget
-            </h2>
-            <div class="space-y-3 text-sm text-gray-600 dark:text-gray-300">
-                {% if app_version %}
-                <p>
-                    <span class="text-gray-500 dark:text-gray-400">Version:</span>
-                    <span class="font-mono">{{ app_version }}</span>
-                </p>
-                {% endif %}
-                <p>
-                    En simpel app til at holde styr på husstandens budget og faste udgifter.
-                </p>
-            </div>
         </section>
 
         {% if donation_links %}


### PR DESCRIPTION
## Summary
- Fjerner 5 sektioner fra help-siden for at gøre den mere overskuelig
- Fjernede sektioner: Indkomst, Udgifter, Forstå overblikket, Tips, Om Budget
- Beholdte sektioner: Kom i gang, Kategorier, Feedback, Støt projektet, Privatlivspolitik, GitHub link

## Test plan
- [x] Unit tests bestået (180 passed)
- [ ] Verificér at help-siden renderer korrekt i browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)