### PR TITLE
fix: make category rename more discoverable

### DIFF
--- a/templates/categories.html
+++ b/templates/categories.html
@@ -32,8 +32,13 @@
     {% if categories %}
     <div class="space-y-3">
         {% for cat in categories %}
-        <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
-            <div class="flex justify-between items-center">
+        <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700">
+            <!-- Clickable name area - opens edit modal -->
+            <button
+                type="button"
+                onclick="openEditModal({{ cat.id }}, '{{ cat.name }}', '{{ cat.icon }}', {{ category_usage[cat.name] }})"
+                class="w-full flex justify-between items-center p-4 rounded-xl hover:bg-gray-50 dark:hover:bg-gray-750 active:bg-gray-100 dark:active:bg-gray-700 transition-colors text-left group"
+            >
                 <div class="flex items-center gap-3">
                     <div class="w-10 h-10 bg-gray-100 dark:bg-gray-700 rounded-lg flex items-center justify-center">
                         <i data-lucide="{{ cat.icon }}" class="w-5 h-5 text-gray-600 dark:text-gray-400"></i>
@@ -49,33 +54,22 @@
                         </div>
                     </div>
                 </div>
-            </div>
-            <div class="flex gap-2 mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
-                <button
-                    onclick="openEditModal({{ cat.id }}, '{{ cat.name }}', '{{ cat.icon }}', {{ category_usage[cat.name] }})"
-                    class="flex-1 text-sm text-gray-600 dark:text-gray-400 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center justify-center gap-1"
-                >
-                    <i data-lucide="pencil" class="w-4 h-4"></i>
-                    Rediger
-                </button>
-                {% if category_usage[cat.name] == 0 %}
-                <form method="post" action="/budget/categories/{{ cat.id }}/delete" class="flex-1">
+                <i data-lucide="pencil" class="w-4 h-4 text-gray-300 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-400 transition-colors"></i>
+            </button>
+            {% if category_usage[cat.name] == 0 %}
+            <div class="px-4 pb-3">
+                <form method="post" action="/budget/categories/{{ cat.id }}/delete">
                     <button
                         type="submit"
                         onclick="return confirm('Slet {{ cat.name }}?')"
-                        class="w-full text-sm text-red-600 dark:text-red-400 py-2 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 flex items-center justify-center gap-1"
+                        class="text-xs text-gray-400 dark:text-gray-500 hover:text-red-500 dark:hover:text-red-400 transition-colors flex items-center gap-1"
                     >
-                        <i data-lucide="trash-2" class="w-4 h-4"></i>
+                        <i data-lucide="trash-2" class="w-3 h-3"></i>
                         Slet
                     </button>
                 </form>
-                {% else %}
-                <div class="flex-1 text-sm text-gray-400 dark:text-gray-600 py-2 rounded-lg flex items-center justify-center gap-1 cursor-not-allowed" title="Kategorien er i brug">
-                    <i data-lucide="lock" class="w-4 h-4"></i>
-                    I brug
-                </div>
-                {% endif %}
             </div>
+            {% endif %}
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
## Summary
- Makes the entire category name row clickable to open the edit modal, instead of requiring users to find the small "Rediger" button
- Adds a subtle pencil icon on each category card as a visual hint that it's editable
- Simplifies card layout by removing the footer action bar — delete is now a small secondary link only shown for unused categories

## Before/After

**Before:** Edit button hidden at the bottom of each card behind a border separator. Users didn't realize they could rename categories.

**After:** Tapping anywhere on the category name/icon opens the edit modal. Pencil icon provides clear visual affordance.

## Test plan
- [x] All 190 unit tests pass
- [x] 2 category-related e2e tests pass
- [ ] Manual: verify tapping category name opens edit modal
- [ ] Manual: verify rename + cascade update still works
- [ ] Manual: verify delete button works for unused categories
- [ ] Manual: verify dark mode looks correct

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)