### PR TITLE
refactor: deduplicate yearly overview logic (#128)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1128,19 +1128,16 @@ def mark_reset_token_used(token_id: int):
 # Demo data functions (returns in-memory data, not from database)
 # =============================================================================
 
-def get_yearly_overview(user_id: int) -> dict:  # noqa: C901, PLR0912
-    """Calculate yearly overview with monthly breakdown.
+def _calculate_yearly_overview(expenses: list, income_entries: list) -> dict:
+    """Shared aggregation logic for yearly overview.
 
-    Returns dict with:
-        categories: {category_name: {1: amount, 2: amount, ..., 12: amount}}
-        totals: {1: total, ..., 12: total}
-        income: {1: amount, ..., 12: amount}
-        balance: {1: amount, ..., 12: amount}
-        year_total: float (total expenses for the year)
+    Args:
+        expenses: List of Expense objects with get_monthly_amounts().
+        income_entries: List of Income objects with get_monthly_amounts().
+
+    Returns:
+        dict with keys: categories, totals, income, balance, year_total.
     """
-    expenses = get_all_expenses(user_id)
-    income_entries = get_all_income(user_id)
-
     # Build category breakdown
     categories: dict[str, dict[int, float]] = {}
     for exp in expenses:
@@ -1150,32 +1147,25 @@ def get_yearly_overview(user_id: int) -> dict:  # noqa: C901, PLR0912
         for m in range(1, 13):
             categories[exp.category][m] += monthly[m]
 
-    # Round all values
+    # Round all category values
     for cat in categories:
         for m in range(1, 13):
             categories[cat][m] = round(categories[cat][m], 2)
 
     # Totals per month
-    totals = {m: 0.0 for m in range(1, 13)}
-    for cat_amounts in categories.values():
-        for m in range(1, 13):
-            totals[m] += cat_amounts[m]
-    for m in range(1, 13):
-        totals[m] = round(totals[m], 2)
+    totals = {m: round(sum(cat[m] for cat in categories.values()), 2) for m in range(1, 13)}
 
-    # Income per month (spread equally, no months support)
+    # Income per month (respects months field via get_monthly_amounts)
     income = {m: 0.0 for m in range(1, 13)}
     for inc in income_entries:
-        monthly_amt = inc.monthly_amount
+        monthly_amounts = inc.get_monthly_amounts()
         for m in range(1, 13):
-            income[m] += monthly_amt
+            income[m] += monthly_amounts[m]
     for m in range(1, 13):
         income[m] = round(income[m], 2)
 
-    # Balance
+    # Balance and year total
     balance = {m: round(income[m] - totals[m], 2) for m in range(1, 13)}
-
-    # Year total
     year_total = round(sum(totals.values()), 2)
 
     return {
@@ -1185,6 +1175,22 @@ def get_yearly_overview(user_id: int) -> dict:  # noqa: C901, PLR0912
         'balance': balance,
         'year_total': year_total,
     }
+
+
+def get_yearly_overview(user_id: int) -> dict:
+    """Calculate yearly overview with monthly breakdown.
+
+    Returns dict with:
+        categories: {category_name: {1: amount, 2: amount, ..., 12: amount}}
+        totals: {1: total, ..., 12: total}
+        income: {1: amount, ..., 12: amount}
+        balance: {1: amount, ..., 12: amount}
+        year_total: float (total expenses for the year)
+    """
+    return _calculate_yearly_overview(
+        get_all_expenses(user_id),
+        get_all_income(user_id),
+    )
 
 
 def get_demo_income(advanced: bool = False) -> list[Income]:
@@ -1259,35 +1265,10 @@ def get_demo_accounts(advanced: bool = False) -> list[Account]:
 
 def get_yearly_overview_demo(advanced: bool = False) -> dict:
     """Get yearly overview for demo mode."""
-    demo_expenses = get_demo_expenses(advanced)
-    demo_income = get_demo_income(advanced)
-
-    categories: dict[str, dict[int, float]] = {}
-    for exp in demo_expenses:
-        if exp.category not in categories:
-            categories[exp.category] = {m: 0.0 for m in range(1, 13)}
-        monthly = exp.get_monthly_amounts()
-        for m in range(1, 13):
-            categories[exp.category][m] += monthly[m]
-
-    for cat in categories:
-        for m in range(1, 13):
-            categories[cat][m] = round(categories[cat][m], 2)
-
-    totals = {m: round(sum(cat[m] for cat in categories.values()), 2) for m in range(1, 13)}
-
-    income = {m: 0.0 for m in range(1, 13)}
-    for inc in demo_income:
-        monthly = inc.get_monthly_amounts()
-        for m in range(1, 13):
-            income[m] += monthly[m]
-    for m in range(1, 13):
-        income[m] = round(income[m], 2)
-
-    balance = {m: round(income[m] - totals[m], 2) for m in range(1, 13)}
-    year_total = round(sum(totals.values()), 2)
-
-    return {'categories': categories, 'totals': totals, 'income': income, 'balance': balance, 'year_total': year_total}
+    return _calculate_yearly_overview(
+        get_demo_expenses(advanced),
+        get_demo_income(advanced),
+    )
 
 
 # Initialize database when run directly (for testing/setup)

--- a/tests/test_yearly_overview_helper.py
+++ b/tests/test_yearly_overview_helper.py
@@ -1,0 +1,74 @@
+"""Tests for the private _calculate_yearly_overview helper."""
+
+import pytest
+
+
+class TestCalculateYearlyOverview:
+    """Tests for the private _calculate_yearly_overview helper."""
+
+    def test_empty_inputs_return_zero_structure(self, db_module):
+        """Empty expenses and income return correct zero-filled structure."""
+        result = db_module._calculate_yearly_overview([], [])
+        assert result['categories'] == {}
+        assert result['year_total'] == 0.0
+        assert list(result['totals'].keys()) == list(range(1, 13))
+        assert all(result['totals'][m] == 0 for m in range(1, 13))
+        assert all(result['income'][m] == 0 for m in range(1, 13))
+        assert all(result['balance'][m] == 0 for m in range(1, 13))
+
+    def test_monthly_expense_appears_every_month(self, db_module):
+        """A monthly expense spreads evenly across all 12 months."""
+        from src.database import Expense
+        expenses = [Expense(id=1, user_id=0, name="Husleje", category="Bolig",
+                            amount=10000, frequency="monthly")]
+        result = db_module._calculate_yearly_overview(expenses, [])
+        assert all(result['categories']['Bolig'][m] == 10000 for m in range(1, 13))
+        assert result['year_total'] == 120000
+
+    def test_expense_with_specific_months(self, db_module):
+        """Expense with months=[3,9] only appears in those months."""
+        from src.database import Expense
+        expenses = [Expense(id=1, user_id=0, name="Forsikring", category="Forsikring",
+                            amount=6000, frequency="semi-annual", months=[3, 9])]
+        result = db_module._calculate_yearly_overview(expenses, [])
+        assert result['categories']['Forsikring'][3] == 3000
+        assert result['categories']['Forsikring'][9] == 3000
+        assert result['categories']['Forsikring'][1] == 0
+        assert result['year_total'] == 6000
+
+    def test_monthly_income_spread_evenly(self, db_module):
+        """Monthly income spreads evenly across all 12 months."""
+        from src.database import Income
+        income = [Income(id=1, user_id=0, person="Person 1",
+                         amount=30000, frequency="monthly")]
+        result = db_module._calculate_yearly_overview([], income)
+        assert all(result['income'][m] == 30000 for m in range(1, 13))
+
+    def test_balance_is_income_minus_expenses(self, db_module):
+        """Balance = income - totals for each month."""
+        from src.database import Expense, Income
+        expenses = [Expense(id=1, user_id=0, name="Husleje", category="Bolig",
+                            amount=10000, frequency="monthly")]
+        income = [Income(id=1, user_id=0, person="Person 1",
+                         amount=30000, frequency="monthly")]
+        result = db_module._calculate_yearly_overview(expenses, income)
+        assert all(result['balance'][m] == 20000 for m in range(1, 13))
+
+    def test_multiple_categories_sum_correctly(self, db_module):
+        """Multiple expense categories aggregate independently."""
+        from src.database import Expense
+        expenses = [
+            Expense(id=1, user_id=0, name="Husleje", category="Bolig",
+                    amount=5000, frequency="monthly"),
+            Expense(id=2, user_id=0, name="Mad", category="Mad",
+                    amount=3000, frequency="monthly"),
+        ]
+        result = db_module._calculate_yearly_overview(expenses, [])
+        assert all(result['categories']['Bolig'][m] == 5000 for m in range(1, 13))
+        assert all(result['categories']['Mad'][m] == 3000 for m in range(1, 13))
+        assert all(result['totals'][m] == 8000 for m in range(1, 13))
+
+    def test_return_structure_has_all_keys(self, db_module):
+        """Return value always has all five expected keys."""
+        result = db_module._calculate_yearly_overview([], [])
+        assert set(result.keys()) == {'categories', 'totals', 'income', 'balance', 'year_total'}


### PR DESCRIPTION
Extracts shared aggregation logic from `get_yearly_overview` and `get_yearly_overview_demo` into a single `_calculate_yearly_overview` helper, eliminating ~60 lines of duplication. Both public functions become thin wrappers.

Also aligns income handling to use `get_monthly_amounts()` consistently in both paths (previously `get_yearly_overview` used the simpler `monthly_amount` property). Removes `# noqa: C901, PLR0912` suppression from `get_yearly_overview` — complexity now lives in the well-tested helper.

## Changes
- `src/database.py`: Add `_calculate_yearly_overview` helper; replace bodies of `get_yearly_overview` and `get_yearly_overview_demo` with wrapper calls
- `tests/test_yearly_overview_helper.py`: 7 new unit tests for the helper (moved to separate file due to file-size constraints on `test_database.py`)

## Test plan
- [x] 7 new `TestCalculateYearlyOverview` tests pass
- [x] All 7 existing `TestYearlyOverview` tests still pass
- [x] Full suite: 261 passed

Closes #128.