### PR TITLE
refactor: remove dead migration helpers (#144)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -326,48 +326,6 @@ def _create_tables(cur) -> None:
     """)
 
 
-def _migrate_categories_add_user_id(cur) -> None:
-    """Add user_id to categories for databases created before per-user categories."""
-    cur.execute("PRAGMA table_info(categories)")
-    cat_columns = [col[1] for col in cur.fetchall()]
-    if "user_id" not in cat_columns:
-        cur.execute("""
-            CREATE TABLE categories_new (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                user_id INTEGER NOT NULL,
-                name TEXT NOT NULL,
-                icon TEXT,
-                UNIQUE(user_id, name)
-            )
-        """)
-        cur.execute("""
-            INSERT INTO categories_new (id, user_id, name, icon)
-            SELECT id, 0, name, icon FROM categories
-        """)
-        cur.execute("DROP TABLE categories")
-        cur.execute("ALTER TABLE categories_new RENAME TO categories")
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_categories_user ON categories(user_id, name)")
-
-
-def _migrate_expenses_add_columns(cur) -> None:
-    """Add category_id, account, and months columns to expenses for older databases."""
-    cur.execute("PRAGMA table_info(expenses)")
-    exp_columns = [col[1] for col in cur.fetchall()]
-    if "category_id" not in exp_columns:
-        cur.execute("ALTER TABLE expenses ADD COLUMN category_id INTEGER REFERENCES categories(id)")
-        cur.execute("CREATE INDEX IF NOT EXISTS idx_expenses_category ON expenses(category_id)")
-    if "account" not in exp_columns:
-        cur.execute("ALTER TABLE expenses ADD COLUMN account TEXT")
-    if "months" not in exp_columns:
-        cur.execute("ALTER TABLE expenses ADD COLUMN months TEXT")
-
-
-def _run_migrations(cur) -> None:
-    """Run schema migrations for existing databases."""
-    _migrate_categories_add_user_id(cur)
-    _migrate_expenses_add_columns(cur)
-
-
 def _seed_default_categories(cur) -> None:
     """Insert default categories for the demo user (user_id = 0)."""
     for name, icon in DEFAULT_CATEGORIES:
@@ -383,7 +341,6 @@ def init_db():
     conn = get_connection()
     cur = conn.cursor()
     _create_tables(cur)
-    _run_migrations(cur)
     _seed_default_categories(cur)
     conn.commit()
     conn.close()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1007,8 +1007,8 @@ class TestExpenseMonthlyAmounts:
         assert all(result[m] == 0 for m in [2, 3, 5, 6, 8, 9, 11, 12])
 
 
-class TestMonthsMigration:
-    """Tests for months column migration."""
+class TestExpenseSchemaColumns:
+    """Tests that expense schema has all required columns."""
 
     def test_months_column_exists_after_init(self, db_module):
         conn = db_module.get_connection()

--- a/tests/test_no_migration_helpers.py
+++ b/tests/test_no_migration_helpers.py
@@ -1,0 +1,17 @@
+"""Ensure dead migration helper functions have been removed (issue #144)."""
+
+
+class TestNoMigrationHelpers:
+    """Ensure migration helper functions have been removed (issue #144)."""
+
+    def test_migrate_categories_add_user_id_removed(self, db_module):
+        assert not hasattr(db_module, "_migrate_categories_add_user_id"), \
+            "_migrate_categories_add_user_id should have been removed"
+
+    def test_migrate_expenses_add_columns_removed(self, db_module):
+        assert not hasattr(db_module, "_migrate_expenses_add_columns"), \
+            "_migrate_expenses_add_columns should have been removed"
+
+    def test_run_migrations_removed(self, db_module):
+        assert not hasattr(db_module, "_run_migrations"), \
+            "_run_migrations should have been removed"


### PR DESCRIPTION
## Summary
- Removes `_migrate_categories_add_user_id`, `_migrate_expenses_add_columns`, and `_run_migrations` from `src/database.py`
- Removes `_run_migrations(cur)` call from `init_db()`
- Renames `TestMonthsMigration` → `TestExpenseSchemaColumns` (tests are schema-validity checks, not migration-path tests)
- Adds `TestNoMigrationHelpers` in new file `tests/test_no_migration_helpers.py` to guard against re-introduction

## Verification
Production DB at `data/budget.db` confirmed to have all migrated columns before removal:
- `categories.user_id` present
- `expenses.category_id`, `account`, `months` present

`_create_tables` already creates the full schema for new databases, so these helpers have been dead code since the `init_db` refactor (issue #133).

## Test results
273 passed, 0 failed

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)