### PR TITLE
feat: upgrade pie chart to doughnut with legend, hover, and empty state (#102)

### DIFF
--- a/e2e/test_charts.py
+++ b/e2e/test_charts.py
@@ -7,11 +7,11 @@ class TestChartRendering:
     """Tests for chart rendering on dashboard."""
 
     def test_chart_section_renders_for_new_user(self, authenticated_page: Page, base_url: str):
-        """Chart section should render even for new users without data."""
+        """Chart section should render empty state placeholder for users without data."""
         authenticated_page.goto(f"{base_url}/budget/")
 
-        # Empty user shows "Ingen data" for category chart
-        expect(authenticated_page.locator("text=Ingen data")).to_be_visible()
+        # Empty state shows icon + descriptive text (scoped to chart empty state)
+        expect(authenticated_page.locator("#chart-empty-state")).to_be_visible()
 
     def test_chart_label_visible(self, authenticated_page: Page, base_url: str):
         """Chart label should be visible."""

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -614,6 +614,7 @@
             container.replaceChildren(); // clear canvas
 
             const wrapper = document.createElement('div');
+            wrapper.id = 'chart-empty-state';
             wrapper.className = 'flex flex-col items-center justify-center h-full py-6 text-center';
 
             const iconBox = document.createElement('div');


### PR DESCRIPTION
## Changes

Upgrades the expense distribution chart on the dashboard:

- **Doughnut variant** with 65% cutout and centered total amount (custom Chart.js plugin)
- **Hover animation**: segments offset outward 12px on hover
- **Extended palette**: 12 harmonious Tailwind-aligned colors (was 8)
- **Custom HTML legend**: color swatch, category name, %, and amount per row
- **Empty state**: pie-chart icon + descriptive text, matches dashboard design system
- **Dark mode**: center text color, border color, and legend text all adapt to dark mode

All changes are frontend-only (templates/dashboard.html). API contract unchanged.

Closes #102