### PR TITLE
feat: add income distribution with per-person transfer plan

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -65,6 +65,7 @@ from .models import (
     Category,
     Expense,
     Income,
+    IncomeSplit,
     PasswordResetToken,
     User,
 )
@@ -79,6 +80,20 @@ from .operations import (
     rename_category_and_cascade_expenses,
 )
 from .schema import DEFAULT_CATEGORIES, init_db
+from .split_store import (
+    AccountTransfer,
+    PersonTransfer,
+    TransferPlan,
+    clear_split_overrides,
+    get_income_by_person,
+    get_split_overrides,
+    get_split_percentages,
+    get_transfer_plan,
+    get_unassigned_expenses,
+    is_split_enabled,
+    set_split_enabled,
+    set_split_override,
+)
 from .security import (
     PBKDF2_ITERATIONS,
     hash_email,
@@ -117,8 +132,22 @@ __all__ = [
     "Expense",
     # models
     "Income",
+    "IncomeSplit",
     "PasswordResetToken",
     "User",
+    # split_store
+    "AccountTransfer",
+    "PersonTransfer",
+    "TransferPlan",
+    "clear_split_overrides",
+    "get_income_by_person",
+    "get_split_overrides",
+    "get_split_percentages",
+    "get_transfer_plan",
+    "get_unassigned_expenses",
+    "is_split_enabled",
+    "set_split_enabled",
+    "set_split_override",
     # budget_store
     "_calculate_yearly_overview",
     "add_account",

--- a/src/db/budget_store.py
+++ b/src/db/budget_store.py
@@ -48,27 +48,27 @@ def get_all_income(user_id: int) -> list[Income]:
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(
-            "SELECT id, user_id, person, amount, frequency FROM income WHERE user_id = ? ORDER BY person",
+            "SELECT id, user_id, person, source, amount, frequency FROM income WHERE user_id = ? ORDER BY person, source",
             (user_id,)
         )
         rows = cur.fetchall()
     return [Income(**dict(row)) for row in rows]
 
 
-def add_income(user_id: int, person: str, amount: float, frequency: str = 'monthly') -> int:
+def add_income(user_id: int, person: str, amount: float, frequency: str = 'monthly', source: str = 'Løn') -> int:
     """Add income entry for a user. Returns the new income ID."""
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(
-            "INSERT INTO income (user_id, person, amount, frequency) VALUES (?, ?, ?, ?)",
-            (user_id, person, amount, frequency)
+            "INSERT INTO income (user_id, person, source, amount, frequency) VALUES (?, ?, ?, ?, ?)",
+            (user_id, person, source, amount, frequency)
         )
         income_id = cur.lastrowid
         conn.commit()
     return income_id
 
 
-def update_income(user_id: int, person: str, amount: float, frequency: str = 'monthly'):
+def update_income(user_id: int, person: str, amount: float, frequency: str = 'monthly', source: str = 'Løn'):
     """Update or insert income for a user.
 
     Uses INSERT ... ON CONFLICT for atomic upsert operation,
@@ -77,10 +77,10 @@ def update_income(user_id: int, person: str, amount: float, frequency: str = 'mo
     with get_connection() as conn:
         cur = conn.cursor()
         cur.execute(
-            """INSERT INTO income (user_id, person, amount, frequency)
-               VALUES (?, ?, ?, ?)
-               ON CONFLICT(user_id, person) DO UPDATE SET amount = excluded.amount, frequency = excluded.frequency""",
-            (user_id, person, amount, frequency)
+            """INSERT INTO income (user_id, person, source, amount, frequency)
+               VALUES (?, ?, ?, ?, ?)
+               ON CONFLICT(user_id, person, source) DO UPDATE SET amount = excluded.amount, frequency = excluded.frequency""",
+            (user_id, person, source, amount, frequency)
         )
         conn.commit()
 

--- a/src/db/demo.py
+++ b/src/db/demo.py
@@ -8,10 +8,10 @@ from .budget_store import _calculate_yearly_overview
 
 # Demo data - typical Danish household budget
 DEMO_INCOME = [
-    # (person, amount, frequency, months)
-    ("Person 1", 28000, "monthly", None),
-    ("Person 2", 22000, "monthly", None),
-    ("Bonus", 30000, "semi-annual", [6, 12]),
+    # (person, source, amount, frequency, months)
+    ("Person 1", "Løn", 28000, "monthly", None),
+    ("Person 2", "Løn", 22000, "monthly", None),
+    ("Bonus", "Bonus", 30000, "semi-annual", [6, 12]),
 ]
 
 DEMO_EXPENSES = [
@@ -41,10 +41,11 @@ DEMO_EXPENSES = [
 ]
 
 DEMO_INCOME_ADVANCED = [
-    ("Person 1", 28000, "monthly", None),
-    ("Person 2", 22000, "monthly", None),
-    ("Bonus", 30000, "semi-annual", [6, 12]),
-    ("Børnepenge", 6264, "quarterly", [1, 4, 7, 10]),
+    # (person, source, amount, frequency, months)
+    ("Person 1", "Løn", 28000, "monthly", None),
+    ("Person 2", "Løn", 22000, "monthly", None),
+    ("Bonus", "Bonus", 30000, "semi-annual", [6, 12]),
+    ("Person 1", "Børnepenge", 6264, "quarterly", [1, 4, 7, 10]),
 ]
 
 DEMO_EXPENSES_ADVANCED = [
@@ -75,9 +76,9 @@ DEMO_EXPENSES_ADVANCED = [
 
 
 def get_demo_income(advanced: bool = False) -> list[Income]:
-    source = DEMO_INCOME_ADVANCED if advanced else DEMO_INCOME
-    return [Income(id=i+1, user_id=0, person=person, amount=amount, frequency=freq, months=months)
-            for i, (person, amount, freq, months) in enumerate(source)]
+    data = DEMO_INCOME_ADVANCED if advanced else DEMO_INCOME
+    return [Income(id=i+1, user_id=0, person=person, amount=amount, source=src, frequency=freq, months=months)
+            for i, (person, src, amount, freq, months) in enumerate(data)]
 
 
 def get_demo_total_income(advanced: bool = False) -> float:

--- a/src/db/facade.py
+++ b/src/db/facade.py
@@ -16,6 +16,15 @@ from .demo import (
     get_yearly_overview_demo,
 )
 from .models import Account, Category, Expense, Income
+from .split_store import (
+    AccountTransfer,
+    PersonTransfer,
+    TransferPlan,
+    get_income_by_person,
+    get_split_percentages,
+    get_transfer_plan,
+    is_split_enabled,
+)
 from .budget_store import (
     get_account_totals,
     get_account_usage_count,
@@ -104,6 +113,71 @@ class DataContext:
         if self.demo:
             return {cat.name: 0 for cat in cats}
         return {cat.name: get_category_usage_count(cat.name, self.user_id) for cat in cats}
+
+    def split_enabled(self) -> bool:
+        if self.demo:
+            return self.advanced  # Demo advanced has split enabled
+        return is_split_enabled(self.user_id)
+
+    def split_percentages(self) -> dict[str, float]:
+        if self.demo:
+            if not self.advanced:
+                return {}
+            # Demo: calculate from demo income
+            income = self.income()
+            totals: dict[str, float] = {}
+            for inc in income:
+                if inc.person not in totals:
+                    totals[inc.person] = 0.0
+                totals[inc.person] += inc.monthly_amount
+            total = sum(totals.values())
+            if total == 0:
+                return {}
+            return {p: round((v / total) * 100, 1) for p, v in totals.items()}
+        return get_split_percentages(self.user_id)
+
+    def transfer_plan(self) -> TransferPlan | None:
+        if not self.split_enabled():
+            return None
+        if self.demo:
+            # Demo mode: calculate plan from demo data
+            percentages = self.split_percentages()
+            if not percentages:
+                return None
+            account_totals = self.account_totals()
+            income_by_person: dict[str, float] = {}
+            for inc in self.income():
+                if inc.person not in income_by_person:
+                    income_by_person[inc.person] = 0.0
+                income_by_person[inc.person] += inc.monthly_amount
+
+            largest_payer = max(percentages, key=lambda p: percentages[p])
+            person_data: dict[str, list[AccountTransfer]] = {p: [] for p in percentages}
+
+            for account, total in account_totals.items():
+                rounded = {}
+                for person, pct in percentages.items():
+                    rounded[person] = int(total * (pct / 100.0))
+                remainder = int(round(total)) - sum(rounded.values())
+                rounded[largest_payer] += remainder
+                for person, amount in rounded.items():
+                    person_data[person].append(AccountTransfer(account=account, amount=amount))
+
+            persons = []
+            for person in percentages:
+                transfers = person_data[person]
+                total_transfer = sum(t.amount for t in transfers)
+                available = int(round(income_by_person.get(person, 0))) - total_transfer
+                persons.append(PersonTransfer(
+                    person=person, transfers=transfers,
+                    total_transfer=total_transfer, available=available,
+                ))
+
+            expenses = self.expenses()
+            unassigned = [e.name for e in expenses if not e.account]
+            return TransferPlan(persons=persons, unassigned_expenses=unassigned[:5], unassigned_count=len(unassigned))
+
+        return get_transfer_plan(self.user_id)
 
     def account_usage(self) -> dict[str, int]:
         """Get usage count per account. Returns all zeros in demo mode."""

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -36,8 +36,16 @@ class Income(MonthlyMixin):
     user_id: int
     person: str
     amount: float
+    source: str = 'Løn'
     frequency: str = 'monthly'
     months: list[int] | None = None
+
+
+@dataclass
+class IncomeSplit:
+    user_id: int
+    person: str
+    percentage_override: float | None  # None = calculate from income
 
 
 @dataclass

--- a/src/db/schema.py
+++ b/src/db/schema.py
@@ -34,12 +34,24 @@ def _create_tables(cur) -> None:
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             person TEXT NOT NULL,
+            source TEXT NOT NULL DEFAULT 'Løn',
             amount REAL NOT NULL DEFAULT 0,
             frequency TEXT NOT NULL DEFAULT 'monthly' CHECK(frequency IN ('monthly', 'quarterly', 'semi-annual', 'yearly')),
+            FOREIGN KEY (user_id) REFERENCES users(id),
+            UNIQUE(user_id, person, source)
+        )
+    """)
+
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS income_split (
+            user_id INTEGER NOT NULL,
+            person TEXT NOT NULL,
+            percentage_override REAL,
             FOREIGN KEY (user_id) REFERENCES users(id),
             UNIQUE(user_id, person)
         )
     """)
+    cur.execute("CREATE INDEX IF NOT EXISTS idx_income_split_user ON income_split(user_id)")
 
     cur.execute("""
         CREATE TABLE IF NOT EXISTS categories (
@@ -90,6 +102,38 @@ def _create_tables(cur) -> None:
             FOREIGN KEY (user_id) REFERENCES users(id)
         )
     """)
+
+
+    # Migrations for existing databases
+    try:
+        cur.execute("ALTER TABLE users ADD COLUMN income_split_enabled BOOLEAN NOT NULL DEFAULT 0")
+    except Exception:
+        pass  # Column already exists
+
+    try:
+        cur.execute("ALTER TABLE income ADD COLUMN source TEXT NOT NULL DEFAULT 'Løn'")
+    except Exception:
+        pass  # Column already exists
+
+    # Migrate income UNIQUE constraint: (user_id, person) -> (user_id, person, source)
+    cur.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name='income'")
+    row = cur.fetchone()
+    if row and 'UNIQUE(user_id, person)' in row[0] and 'UNIQUE(user_id, person, source)' not in row[0]:
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS income_new (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                user_id INTEGER NOT NULL,
+                person TEXT NOT NULL,
+                source TEXT NOT NULL DEFAULT 'Løn',
+                amount REAL NOT NULL DEFAULT 0,
+                frequency TEXT NOT NULL DEFAULT 'monthly' CHECK(frequency IN ('monthly', 'quarterly', 'semi-annual', 'yearly')),
+                FOREIGN KEY (user_id) REFERENCES users(id),
+                UNIQUE(user_id, person, source)
+            )
+        """)
+        cur.execute("INSERT INTO income_new (id, user_id, person, source, amount, frequency) SELECT id, user_id, person, 'Løn', amount, frequency FROM income")
+        cur.execute("DROP TABLE income")
+        cur.execute("ALTER TABLE income_new RENAME TO income")
 
 
 def _seed_default_categories(cur) -> None:

--- a/src/db/split_store.py
+++ b/src/db/split_store.py
@@ -1,0 +1,219 @@
+"""Income split CRUD and transfer plan calculation.
+
+Handles the income distribution feature: split percentages,
+overrides, and transfer plan generation.
+"""
+
+from dataclasses import dataclass
+
+from .budget_store import get_account_totals, get_all_income
+from .connection import get_connection
+
+
+@dataclass
+class AccountTransfer:
+    account: str
+    amount: int  # whole kroner
+
+
+@dataclass
+class PersonTransfer:
+    person: str
+    transfers: list[AccountTransfer]
+    total_transfer: int
+    available: int  # income minus total transfers
+
+
+@dataclass
+class TransferPlan:
+    persons: list[PersonTransfer]
+    unassigned_expenses: list[str]
+    unassigned_count: int
+
+
+def is_split_enabled(user_id: int) -> bool:
+    """Check if income split is enabled for a user."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute("SELECT income_split_enabled FROM users WHERE id = ?", (user_id,))
+        row = cur.fetchone()
+    return bool(row and row[0])
+
+
+def set_split_enabled(user_id: int, enabled: bool) -> None:
+    """Enable or disable income split for a user."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "UPDATE users SET income_split_enabled = ? WHERE id = ?",
+            (1 if enabled else 0, user_id)
+        )
+        conn.commit()
+
+
+def get_split_overrides(user_id: int) -> dict[str, float | None]:
+    """Get split percentage overrides for a user."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT person, percentage_override FROM income_split WHERE user_id = ?",
+            (user_id,)
+        )
+        rows = cur.fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
+def set_split_override(user_id: int, person: str, percentage: float | None) -> None:
+    """Set or clear a split percentage override for a person."""
+    with get_connection() as conn:
+        cur = conn.cursor()
+        if percentage is None:
+            cur.execute(
+                "DELETE FROM income_split WHERE user_id = ? AND person = ?",
+                (user_id, person)
+            )
+        else:
+            cur.execute(
+                """INSERT INTO income_split (user_id, person, percentage_override)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(user_id, person) DO UPDATE SET percentage_override = excluded.percentage_override""",
+                (user_id, person, percentage)
+            )
+        conn.commit()
+
+
+def clear_split_overrides(user_id: int) -> None:
+    """Remove all split overrides for a user."""
+    with get_connection() as conn:
+        conn.execute("DELETE FROM income_split WHERE user_id = ?", (user_id,))
+        conn.commit()
+
+
+def get_income_by_person(user_id: int) -> dict[str, float]:
+    """Get total monthly income grouped by person."""
+    incomes = get_all_income(user_id)
+    totals: dict[str, float] = {}
+    for inc in incomes:
+        if inc.person not in totals:
+            totals[inc.person] = 0.0
+        totals[inc.person] += inc.monthly_amount
+    return totals
+
+
+def get_split_percentages(user_id: int) -> dict[str, float]:
+    """Get split percentages per person.
+
+    Uses overrides if set, otherwise calculates proportionally from income.
+    """
+    income_by_person = get_income_by_person(user_id)
+    if not income_by_person:
+        return {}
+
+    overrides = get_split_overrides(user_id)
+    total_income = sum(income_by_person.values())
+
+    if total_income == 0:
+        return {}
+
+    # If all persons have overrides, use them
+    all_overridden = all(
+        person in overrides and overrides[person] is not None
+        for person in income_by_person
+    )
+    if all_overridden:
+        return {person: overrides[person] for person in income_by_person}
+
+    # Calculate proportionally
+    result = {}
+    for person, income in income_by_person.items():
+        if person in overrides and overrides[person] is not None:
+            result[person] = overrides[person]
+        else:
+            result[person] = round((income / total_income) * 100, 1)
+
+    # Ensure percentages sum to 100 by adjusting last non-overridden person
+    total_pct = sum(result.values())
+    if abs(total_pct - 100.0) > 0.01:
+        non_overridden = [p for p in income_by_person if p not in overrides or overrides[p] is None]
+        if non_overridden:
+            last = non_overridden[-1]
+            result[last] = round(result[last] + (100.0 - total_pct), 1)
+
+    return result
+
+
+def get_unassigned_expenses(user_id: int, limit: int = 5) -> tuple[list[str], int]:
+    """Get names of expenses without an account assignment.
+
+    Returns (first N names, total count).
+    """
+    with get_connection() as conn:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT COUNT(*) FROM expenses WHERE user_id = ? AND (account IS NULL OR account = '')",
+            (user_id,)
+        )
+        count = cur.fetchone()[0]
+
+        cur.execute(
+            "SELECT name FROM expenses WHERE user_id = ? AND (account IS NULL OR account = '') ORDER BY name LIMIT ?",
+            (user_id, limit)
+        )
+        names = [row[0] for row in cur.fetchall()]
+    return names, count
+
+
+def get_transfer_plan(user_id: int) -> TransferPlan:
+    """Calculate the full transfer plan for a user.
+
+    Returns per-person, per-account transfer amounts in whole kroner,
+    with rounding remainder assigned to the largest payer.
+    """
+    percentages = get_split_percentages(user_id)
+    if not percentages:
+        return TransferPlan(persons=[], unassigned_expenses=[], unassigned_count=0)
+
+    account_totals = get_account_totals(user_id)
+    income_by_person = get_income_by_person(user_id)
+    unassigned_names, unassigned_count = get_unassigned_expenses(user_id)
+
+    # Find person with highest percentage (largest payer)
+    largest_payer = max(percentages, key=lambda p: percentages[p])
+
+    person_data: dict[str, list[AccountTransfer]] = {p: [] for p in percentages}
+
+    for account, total in account_totals.items():
+        # Calculate each person's share
+        raw_shares = {}
+        for person, pct in percentages.items():
+            raw_shares[person] = total * (pct / 100.0)
+
+        # Round to whole kroner
+        rounded = {person: int(amount) for person, amount in raw_shares.items()}
+        remainder = int(round(total)) - sum(rounded.values())
+
+        # Assign remainder to largest payer
+        rounded[largest_payer] += remainder
+
+        for person, amount in rounded.items():
+            person_data[person].append(AccountTransfer(account=account, amount=amount))
+
+    # Build PersonTransfer objects
+    persons = []
+    for person in percentages:
+        transfers = person_data[person]
+        total_transfer = sum(t.amount for t in transfers)
+        person_income = int(round(income_by_person.get(person, 0)))
+        available = person_income - total_transfer
+        persons.append(PersonTransfer(
+            person=person,
+            transfers=transfers,
+            total_transfer=total_transfer,
+            available=available,
+        ))
+
+    return TransferPlan(
+        persons=persons,
+        unassigned_expenses=unassigned_names,
+        unassigned_count=unassigned_count,
+    )

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -30,6 +30,9 @@ async def dashboard(request: Request, ctx: DataContext = Depends(get_data)):
         for cat, total in category_totals.items():
             category_percentages[cat] = (total / total_expenses) * 100
 
+    # Income distribution
+    transfer_plan = ctx.transfer_plan()
+
     return templates.TemplateResponse(
         "dashboard.html",
         {
@@ -45,5 +48,6 @@ async def dashboard(request: Request, ctx: DataContext = Depends(get_data)):
             "yearly_overview": yearly_overview,
             "demo_mode": ctx.demo,
             "demo_advanced": ctx.advanced,
+            "transfer_plan": transfer_plan,
         }
     )

--- a/src/routes/income.py
+++ b/src/routes/income.py
@@ -24,10 +24,23 @@ router = APIRouter(prefix="/budget")
 async def income_page(request: Request, ctx: DataContext = Depends(get_data)):
     """Income edit page."""
     incomes = ctx.income()
+    split_enabled = ctx.split_enabled()
+    split_percentages = ctx.split_percentages()
+
+    # Get unique persons for split display
+    persons = list(dict.fromkeys(inc.person for inc in incomes))
 
     return templates.TemplateResponse(
         "income.html",
-        {"request": request, "incomes": incomes, "demo_mode": ctx.demo, "demo_advanced": ctx.advanced}
+        {
+            "request": request,
+            "incomes": incomes,
+            "demo_mode": ctx.demo,
+            "demo_advanced": ctx.advanced,
+            "split_enabled": split_enabled,
+            "split_percentages": split_percentages,
+            "persons": persons,
+        }
     )
 
 
@@ -38,23 +51,45 @@ async def update_income(request: Request, _: None = Depends(require_write("/budg
     form = await request.form()
 
     try:
-        # Parse dynamic form fields: income_name_0, income_amount_0, income_frequency_0, etc.
+        # Handle split toggle
+        split_enabled = form.get("split_enabled") == "on"
+        db.set_split_enabled(user_id, split_enabled)
+
+        # Parse dynamic form fields
         incomes_to_save = []
         i = 0
         while f"income_name_{i}" in form:
             name = form.get(f"income_name_{i}", "").strip()
+            source = form.get(f"income_source_{i}", "Løn").strip() or "Løn"
             amount_str = form.get(f"income_amount_{i}", "0")
             frequency = form.get(f"income_frequency_{i}", "monthly")
-            if name:  # Only save if name is provided
+            if name:
                 result = validate_income(name, amount_str if amount_str else "0", frequency)
                 result.raise_if_invalid()
-                incomes_to_save.append((result.parsed["name"], result.parsed["amount"], result.parsed["frequency"]))
+                incomes_to_save.append((result.parsed["name"], source, result.parsed["amount"], result.parsed["frequency"]))
             i += 1
 
         # Clear existing and save new
         db.delete_all_income(user_id)
-        for name, amount, frequency in incomes_to_save:
-            db.add_income(user_id, name, amount, frequency)
+        for name, source, amount, frequency in incomes_to_save:
+            db.add_income(user_id, name, amount, frequency, source)
+
+        # Handle split overrides if enabled
+        if split_enabled:
+            persons = list(dict.fromkeys(name for name, _, _, _ in incomes_to_save))
+            db.clear_split_overrides(user_id)
+            has_overrides = False
+            for person in persons:
+                override_str = form.get(f"split_pct_{person}")
+                if override_str:
+                    try:
+                        pct = float(override_str.replace(",", "."))
+                        db.set_split_override(user_id, person, pct)
+                        has_overrides = True
+                    except ValueError:
+                        pass
+            if not has_overrides:
+                db.clear_split_overrides(user_id)
 
     except (ValueError, sqlite3.Error) as e:
         logger.error(f"Error updating income: {e}")

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -194,6 +194,75 @@
         {% endif %}
         </div>
 
+        <!-- Income Distribution Plan -->
+        <div data-section-id="income-distribution">
+        {% if transfer_plan %}
+        <div class="group/section mt-6">
+            <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
+                <div class="flex justify-between items-center mb-3">
+                    <div class="flex items-center gap-1">
+                        <div class="drag-handle cursor-grab active:cursor-grabbing opacity-0 group-hover/section:opacity-100 transition-opacity p-1 -ml-2">
+                            <i data-lucide="grip-vertical" class="w-4 h-4 text-gray-400"></i>
+                        </div>
+                        <h2 class="text-sm font-medium text-gray-600 dark:text-gray-400">Indkomstfordeling</h2>
+                    </div>
+                    <a href="/budget/income" class="text-xs text-primary hover:text-blue-600 flex items-center gap-1">
+                        Indstillinger
+                        <i data-lucide="chevron-right" class="w-3 h-3"></i>
+                    </a>
+                </div>
+
+                {% for person in transfer_plan.persons %}
+                <div class="{% if not loop.first %}mt-4 pt-4 border-t border-gray-100 dark:border-gray-700{% endif %}">
+                    <div class="flex justify-between items-center mb-2">
+                        <span class="font-medium text-gray-900 dark:text-white">{{ person.person }}</span>
+                        <span class="text-sm text-emerald-600 dark:text-emerald-400">
+                            Til rådighed: <span data-monthly="{{ person.available }}" data-yearly="{{ person.available * 12 }}">{{ format_currency(person.available) }}</span><span class="period-suffix">/md</span>
+                        </span>
+                    </div>
+                    <div class="space-y-1.5">
+                        {% for transfer in person.transfers %}
+                        {% if transfer.amount > 0 %}
+                        <div class="flex justify-between items-center text-sm">
+                            <div class="flex items-center gap-2">
+                                <i data-lucide="arrow-right" class="w-3 h-3 text-gray-400"></i>
+                                <span class="text-gray-600 dark:text-gray-400">{{ transfer.account }}</span>
+                            </div>
+                            <span class="font-medium text-gray-900 dark:text-white">
+                                <span data-monthly="{{ transfer.amount }}" data-yearly="{{ transfer.amount * 12 }}">{{ format_currency(transfer.amount) }}</span><span class="period-suffix">/md</span>
+                            </span>
+                        </div>
+                        {% endif %}
+                        {% endfor %}
+                    </div>
+                    <div class="mt-1.5 text-xs text-gray-500 dark:text-gray-500 text-right">
+                        Total: <span data-monthly="{{ person.total_transfer }}" data-yearly="{{ person.total_transfer * 12 }}">{{ format_currency(person.total_transfer) }}</span><span class="period-suffix">/md</span>
+                    </div>
+                </div>
+                {% endfor %}
+
+                {% if transfer_plan.persons|length > 0 and transfer_plan.persons[0].transfers|length == 0 %}
+                <div class="text-center py-3">
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        <i data-lucide="landmark" class="w-4 h-4 inline mr-1"></i>
+                        Tilføj konti og tildel udgifter for at se overførselsplanen
+                    </p>
+                </div>
+                {% endif %}
+
+                {% if transfer_plan.unassigned_count > 0 %}
+                <div class="mt-3 pt-3 border-t border-gray-100 dark:border-gray-700">
+                    <p class="text-xs text-gray-400 dark:text-gray-500">
+                        <i data-lucide="info" class="w-3 h-3 inline mr-1"></i>
+                        {{ transfer_plan.unassigned_count }} udgift{{ 'er' if transfer_plan.unassigned_count != 1 else '' }} uden konto{% if transfer_plan.unassigned_expenses %}: {{ transfer_plan.unassigned_expenses|join(', ') }}{% if transfer_plan.unassigned_count > transfer_plan.unassigned_expenses|length %} ...{% endif %}{% endif %}
+                    </p>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+        </div>
+
         <!-- Income breakdown (small) -->
         <div data-section-id="income-breakdown">
         <div class="group/section mt-6">
@@ -463,6 +532,7 @@
     const DEFAULT_SECTION_ORDER = [
         'expenses-breakdown',
         'transfer-summary',
+        'income-distribution',
         'income-breakdown',
         'category-chart',
         'yearly-overview'

--- a/templates/income.html
+++ b/templates/income.html
@@ -34,6 +34,54 @@
     </div>
     {% endif %}
 
+    <!-- Income Split Toggle -->
+    <div class="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700 mb-4">
+        <label class="flex items-center justify-between cursor-pointer">
+            <div>
+                <span class="font-medium text-gray-900 dark:text-white">Indkomstfordeling</span>
+                <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Beregn overførsler per person til konti</p>
+            </div>
+            <div class="relative">
+                <input type="checkbox" name="split_enabled" id="split-toggle" class="sr-only peer"
+                    {% if split_enabled %}checked{% endif %}
+                    onchange="toggleSplitSection()"
+                    form="income-form">
+                <div class="w-11 h-6 bg-gray-200 peer-focus:ring-2 peer-focus:ring-primary rounded-full peer dark:bg-gray-600 peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-primary"></div>
+            </div>
+        </label>
+    </div>
+
+    <!-- Split Percentages (visible when toggle is on) -->
+    <div id="split-section" class="{% if not split_enabled %}hidden{% endif %} bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700 mb-4">
+        <h3 class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-3">Fordelingsnøgle</h3>
+        <div id="split-controls" class="space-y-3">
+            {% for person in persons %}
+            <div class="split-person" data-person="{{ person }}">
+                <div class="flex items-center justify-between mb-1">
+                    <span class="text-sm text-gray-700 dark:text-gray-300">{{ person }}</span>
+                    <div class="flex items-center gap-2">
+                        <input type="number" name="split_pct_{{ person }}"
+                            value="{{ split_percentages.get(person, 0)|round(0)|int }}"
+                            min="0" max="100" step="1"
+                            class="w-16 text-right text-sm px-2 py-1 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white"
+                            oninput="onSplitInputChange(this)"
+                            form="income-form">
+                        <span class="text-sm text-gray-500">%</span>
+                    </div>
+                </div>
+                <input type="range" min="0" max="100" step="1"
+                    value="{{ split_percentages.get(person, 0)|round(0)|int }}"
+                    class="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-600 accent-primary"
+                    oninput="onSplitSliderChange(this)">
+            </div>
+            {% endfor %}
+        </div>
+        <div class="mt-2 flex justify-between items-center">
+            <span id="split-total" class="text-xs text-gray-500 dark:text-gray-400">Total: {% if persons %}{{ split_percentages.values()|sum|round(0)|int }}{% else %}0{% endif %}%</span>
+            <button type="button" onclick="resetSplit()" class="text-xs text-primary hover:text-blue-600">Nulstil</button>
+        </div>
+    </div>
+
     <form method="post" action="/budget/income" class="space-y-4" id="income-form">
         <!-- Dynamisk liste af indtægtskilder -->
         <div id="income-list" class="space-y-4">
@@ -60,6 +108,16 @@
                         <i data-lucide="trash-2" class="w-5 h-5"></i>
                     </button>
                 </div>
+                <label class="block mb-3">
+                    <span class="text-gray-500 dark:text-gray-400 text-sm">Kilde</span>
+                    <input
+                        type="text"
+                        name="income_source_{{ loop.index0 }}"
+                        value="{{ income.source if income.source else 'Løn' }}"
+                        placeholder="F.eks. Løn, Børnepenge"
+                        class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                    >
+                </label>
                 <div class="grid grid-cols-2 gap-3 mb-3">
                     <label class="block">
                         <span class="text-gray-500 dark:text-gray-400 text-sm">Beløb</span>
@@ -157,6 +215,16 @@
                         <i data-lucide="trash-2" class="w-5 h-5"></i>
                     </button>
                 </div>
+                <label class="block mb-3">
+                    <span class="text-gray-500 dark:text-gray-400 text-sm">Kilde</span>
+                    <input
+                        type="text"
+                        name="income_source_${incomeIndex}"
+                        value="Løn"
+                        placeholder="F.eks. Løn, Børnepenge"
+                        class="w-full px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-white text-sm"
+                    >
+                </label>
                 <div class="grid grid-cols-2 gap-3 mb-3">
                     <label class="block">
                         <span class="text-gray-500 dark:text-gray-400 text-sm">Beløb</span>
@@ -226,10 +294,80 @@
     function reindexIncomes() {
         document.querySelectorAll('.income-item').forEach((item, i) => {
             item.querySelector('[name^="income_name_"]').name = `income_name_${i}`;
+            item.querySelector('[name^="income_source_"]').name = `income_source_${i}`;
             item.querySelector('[name^="income_amount_"]').name = `income_amount_${i}`;
             item.querySelector('[name^="income_frequency_"]').name = `income_frequency_${i}`;
         });
         incomeIndex = document.querySelectorAll('.income-item').length;
+    }
+    function toggleSplitSection() {
+        const section = document.getElementById('split-section');
+        const toggle = document.getElementById('split-toggle');
+        section.classList.toggle('hidden', !toggle.checked);
+    }
+
+    function onSplitSliderChange(slider) {
+        const personDiv = slider.closest('.split-person');
+        const input = personDiv.querySelector('input[type="number"]');
+        input.value = slider.value;
+        balanceSplit(personDiv);
+    }
+
+    function onSplitInputChange(input) {
+        const personDiv = input.closest('.split-person');
+        const slider = personDiv.querySelector('input[type="range"]');
+        slider.value = input.value;
+        balanceSplit(personDiv);
+    }
+
+    function balanceSplit(changedDiv) {
+        const allDivs = document.querySelectorAll('.split-person');
+        if (allDivs.length < 2) return;
+
+        const changedInput = changedDiv.querySelector('input[type="number"]');
+        const changedValue = parseFloat(changedInput.value) || 0;
+
+        if (allDivs.length === 2) {
+            allDivs.forEach(div => {
+                if (div !== changedDiv) {
+                    const input = div.querySelector('input[type="number"]');
+                    const slider = div.querySelector('input[type="range"]');
+                    const other = Math.max(0, Math.min(100, 100 - changedValue));
+                    input.value = other;
+                    slider.value = other;
+                }
+            });
+        } else {
+            const others = Array.from(allDivs).filter(d => d !== changedDiv);
+            const otherTotal = others.reduce((sum, d) => {
+                return sum + (parseFloat(d.querySelector('input[type="number"]').value) || 0);
+            }, 0);
+            const remaining = Math.max(0, 100 - changedValue);
+
+            others.forEach(div => {
+                const input = div.querySelector('input[type="number"]');
+                const slider = div.querySelector('input[type="range"]');
+                const currentVal = parseFloat(input.value) || 0;
+                const ratio = otherTotal > 0 ? currentVal / otherTotal : 1 / others.length;
+                const newVal = Math.round(remaining * ratio);
+                input.value = newVal;
+                slider.value = newVal;
+            });
+        }
+        updateSplitTotal();
+    }
+
+    function updateSplitTotal() {
+        const inputs = document.querySelectorAll('.split-person input[type="number"]');
+        const total = Array.from(inputs).reduce((sum, inp) => sum + (parseFloat(inp.value) || 0), 0);
+        const el = document.getElementById('split-total');
+        if (el) el.textContent = `Total: ${total}%`;
+    }
+
+    function resetSplit() {
+        document.querySelectorAll('.split-person input[type="number"]').forEach(inp => inp.value = '');
+        document.querySelectorAll('.split-person input[type="range"]').forEach(inp => inp.value = 0);
+        updateSplitTotal();
     }
     </script>
 

--- a/tests/test_income_split.py
+++ b/tests/test_income_split.py
@@ -1,0 +1,294 @@
+"""Tests for income split (distribution) feature."""
+
+import sqlite3
+
+import pytest
+
+
+class TestIncomeSourceSchema:
+    """Tests for multiple income sources per person."""
+
+    def test_add_income_with_source(self, db_module):
+        """Income entries should support a source field."""
+        user_id = db_module.create_user("splituser1", "testpass")
+        income_id = db_module.add_income(user_id, "Person 1", 25000, "monthly", "Løn")
+        assert income_id is not None
+
+        incomes = db_module.get_all_income(user_id)
+        assert len(incomes) == 1
+        assert incomes[0].person == "Person 1"
+        assert incomes[0].source == "Løn"
+        assert incomes[0].amount == 25000
+
+    def test_multiple_sources_per_person(self, db_module):
+        """Same person can have multiple income sources."""
+        user_id = db_module.create_user("splituser2", "testpass")
+        db_module.add_income(user_id, "Person 1", 25000, "monthly", "Løn")
+        db_module.add_income(user_id, "Person 1", 2100, "quarterly", "Børnepenge")
+
+        incomes = db_module.get_all_income(user_id)
+        assert len(incomes) == 2
+        person1 = [i for i in incomes if i.person == "Person 1"]
+        assert len(person1) == 2
+        sources = {i.source for i in person1}
+        assert sources == {"Løn", "Børnepenge"}
+
+    def test_unique_constraint_person_source(self, db_module):
+        """Same person+source combination should be unique per user."""
+        user_id = db_module.create_user("splituser3", "testpass")
+        db_module.add_income(user_id, "Person 1", 25000, "monthly", "Løn")
+
+        with pytest.raises(sqlite3.IntegrityError):
+            db_module.add_income(user_id, "Person 1", 30000, "monthly", "Løn")
+
+
+class TestSplitEnabled:
+    """Tests for income split toggle."""
+
+    def test_split_disabled_by_default(self, db_module):
+        user_id = db_module.create_user("split_en1", "testpass")
+        assert db_module.is_split_enabled(user_id) is False
+
+    def test_enable_split(self, db_module):
+        user_id = db_module.create_user("split_en2", "testpass")
+        db_module.set_split_enabled(user_id, True)
+        assert db_module.is_split_enabled(user_id) is True
+
+    def test_disable_split(self, db_module):
+        user_id = db_module.create_user("split_en3", "testpass")
+        db_module.set_split_enabled(user_id, True)
+        db_module.set_split_enabled(user_id, False)
+        assert db_module.is_split_enabled(user_id) is False
+
+
+class TestIncomeByPerson:
+    """Tests for income grouped by person."""
+
+    def test_income_by_person_single(self, db_module):
+        user_id = db_module.create_user("ibp1", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        result = db_module.get_income_by_person(user_id)
+        assert result == {"Alice": 30000.0}
+
+    def test_income_by_person_multiple_sources(self, db_module):
+        user_id = db_module.create_user("ibp2", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Alice", 6000, "quarterly", "Børnepenge")
+        result = db_module.get_income_by_person(user_id)
+        assert result == {"Alice": 32000.0}  # 30000 + 6000/3
+
+    def test_income_by_person_two_persons(self, db_module):
+        user_id = db_module.create_user("ibp3", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        result = db_module.get_income_by_person(user_id)
+        assert result == {"Alice": 30000.0, "Bob": 20000.0}
+
+
+class TestSplitPercentages:
+    """Tests for split percentage calculation."""
+
+    def test_proportional_split_two_persons(self, db_module):
+        user_id = db_module.create_user("sp1", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        result = db_module.get_split_percentages(user_id)
+        assert result == {"Alice": 60.0, "Bob": 40.0}
+
+    def test_override_split(self, db_module):
+        user_id = db_module.create_user("sp2", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        db_module.set_split_override(user_id, "Alice", 55.0)
+        db_module.set_split_override(user_id, "Bob", 45.0)
+        result = db_module.get_split_percentages(user_id)
+        assert result == {"Alice": 55.0, "Bob": 45.0}
+
+    def test_empty_income_returns_empty(self, db_module):
+        user_id = db_module.create_user("sp3", "testpass")
+        result = db_module.get_split_percentages(user_id)
+        assert result == {}
+
+    def test_single_person_is_100(self, db_module):
+        user_id = db_module.create_user("sp4", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        result = db_module.get_split_percentages(user_id)
+        assert result == {"Alice": 100.0}
+
+
+class TestTransferPlan:
+    """Tests for transfer plan calculation."""
+
+    def test_basic_transfer_plan(self, db_module):
+        user_id = db_module.create_user("tp1", "testpass")
+        # Income: Alice 60%, Bob 40%
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        db_module.set_split_enabled(user_id, True)
+        # Add account and expense
+        db_module.add_account(user_id, "Budgetkonto")
+        db_module.add_expense(user_id, "Husleje", "Bolig", 10000, "monthly", "Budgetkonto")
+
+        plan = db_module.get_transfer_plan(user_id)
+        assert len(plan.persons) == 2
+
+        alice = next(p for p in plan.persons if p.person == "Alice")
+        bob = next(p for p in plan.persons if p.person == "Bob")
+
+        # Alice: 60% of 10000 = 6000, Bob: 40% of 10000 = 4000
+        alice_budget = next(t for t in alice.transfers if t.account == "Budgetkonto")
+        bob_budget = next(t for t in bob.transfers if t.account == "Budgetkonto")
+        assert alice_budget.amount == 6000
+        assert bob_budget.amount == 4000
+
+        # Available: Alice 30000-6000=24000, Bob 20000-4000=16000
+        assert alice.available == 24000
+        assert bob.available == 16000
+
+    def test_rounding_remainder_to_largest_payer(self, db_module):
+        user_id = db_module.create_user("tp2", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        db_module.set_split_enabled(user_id, True)
+        db_module.add_account(user_id, "Konto")
+        # 10001 * 0.6 = 6000.6 -> 6000, 10001 * 0.4 = 4000.4 -> 4000
+        # remainder = 10001 - 10000 = 1 -> goes to Alice (largest payer)
+        db_module.add_expense(user_id, "Test", "Bolig", 10001, "monthly", "Konto")
+
+        plan = db_module.get_transfer_plan(user_id)
+        alice = next(p for p in plan.persons if p.person == "Alice")
+        bob = next(p for p in plan.persons if p.person == "Bob")
+        alice_amt = next(t for t in alice.transfers if t.account == "Konto").amount
+        bob_amt = next(t for t in bob.transfers if t.account == "Konto").amount
+        assert alice_amt + bob_amt == 10001
+        # Alice is largest payer, gets the remainder
+        assert alice_amt == 6001
+        assert bob_amt == 4000
+
+    def test_unassigned_expenses_in_plan(self, db_module):
+        user_id = db_module.create_user("tp3", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.set_split_enabled(user_id, True)
+        # Expenses without account
+        db_module.add_expense(user_id, "Netflix", "Abonnementer", 129, "monthly")
+        db_module.add_expense(user_id, "Spotify", "Abonnementer", 99, "monthly")
+
+        plan = db_module.get_transfer_plan(user_id)
+        assert plan.unassigned_count == 2
+        assert "Netflix" in plan.unassigned_expenses
+        assert "Spotify" in plan.unassigned_expenses
+
+
+class TestUnassignedExpenses:
+    """Tests for unassigned expense detection."""
+
+    def test_no_unassigned(self, db_module):
+        user_id = db_module.create_user("ue1", "testpass")
+        db_module.add_account(user_id, "Konto")
+        db_module.add_expense(user_id, "Husleje", "Bolig", 10000, "monthly", "Konto")
+        names, count = db_module.get_unassigned_expenses(user_id)
+        assert names == []
+        assert count == 0
+
+    def test_some_unassigned(self, db_module):
+        user_id = db_module.create_user("ue2", "testpass")
+        db_module.add_expense(user_id, "Netflix", "Abonnementer", 129, "monthly")
+        db_module.add_expense(user_id, "Husleje", "Bolig", 10000, "monthly", "Budgetkonto")
+        names, count = db_module.get_unassigned_expenses(user_id)
+        assert count == 1
+        assert names == ["Netflix"]
+
+    def test_limit_unassigned(self, db_module):
+        user_id = db_module.create_user("ue3", "testpass")
+        for i in range(10):
+            db_module.add_expense(user_id, f"Expense {i}", "Andet", 100, "monthly")
+        names, count = db_module.get_unassigned_expenses(user_id, limit=5)
+        assert count == 10
+        assert len(names) == 5
+
+
+class TestSplitIntegration:
+    """Integration tests for income split full flow."""
+
+    def test_full_flow_two_persons(self, db_module):
+        """Full flow: add income, enable split, get transfer plan."""
+        user_id = db_module.create_user("integ1", "testpass")
+
+        # Add income
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Alice", 3000, "quarterly", "Børnepenge")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+
+        # Add accounts and expenses
+        db_module.add_account(user_id, "Budgetkonto")
+        db_module.add_account(user_id, "Madkonto")
+        db_module.add_expense(user_id, "Husleje", "Bolig", 12000, "monthly", "Budgetkonto")
+        db_module.add_expense(user_id, "Dagligvarer", "Mad", 6000, "monthly", "Madkonto")
+        db_module.add_expense(user_id, "Netflix", "Abonnementer", 129, "monthly")  # No account
+
+        # Enable split
+        db_module.set_split_enabled(user_id, True)
+
+        # Get plan
+        plan = db_module.get_transfer_plan(user_id)
+        assert len(plan.persons) == 2
+        assert plan.unassigned_count == 1
+        assert "Netflix" in plan.unassigned_expenses
+
+        # Verify amounts sum correctly per account
+        for account_name in ["Budgetkonto", "Madkonto"]:
+            total = sum(
+                t.amount
+                for p in plan.persons
+                for t in p.transfers
+                if t.account == account_name
+            )
+            # Account total should match expense total for that account
+            account_totals = db_module.get_account_totals(user_id)
+            assert total == int(round(account_totals[account_name]))
+
+    def test_single_person_split(self, db_module):
+        """Single person gets 100% of everything."""
+        user_id = db_module.create_user("integ2", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.set_split_enabled(user_id, True)
+        db_module.add_account(user_id, "Konto")
+        db_module.add_expense(user_id, "Husleje", "Bolig", 10000, "monthly", "Konto")
+
+        plan = db_module.get_transfer_plan(user_id)
+        assert len(plan.persons) == 1
+        assert plan.persons[0].person == "Alice"
+        assert plan.persons[0].transfers[0].amount == 10000
+        assert plan.persons[0].available == 20000
+
+    def test_no_accounts_empty_plan(self, db_module):
+        """No accounts means empty transfers but plan still works."""
+        user_id = db_module.create_user("integ3", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.set_split_enabled(user_id, True)
+
+        plan = db_module.get_transfer_plan(user_id)
+        assert len(plan.persons) == 1
+        assert plan.persons[0].transfers == []
+        assert plan.persons[0].total_transfer == 0
+        assert plan.persons[0].available == 30000
+
+    def test_zero_income_empty_percentages(self, db_module):
+        """Zero income returns empty percentages."""
+        user_id = db_module.create_user("integ4", "testpass")
+        result = db_module.get_split_percentages(user_id)
+        assert result == {}
+
+    def test_override_persists_after_toggle(self, db_module):
+        """Overrides should persist when toggling split off and on."""
+        user_id = db_module.create_user("integ5", "testpass")
+        db_module.add_income(user_id, "Alice", 30000, "monthly", "Løn")
+        db_module.add_income(user_id, "Bob", 20000, "monthly", "Løn")
+        db_module.set_split_override(user_id, "Alice", 55.0)
+        db_module.set_split_override(user_id, "Bob", 45.0)
+
+        db_module.set_split_enabled(user_id, False)
+        db_module.set_split_enabled(user_id, True)
+
+        result = db_module.get_split_percentages(user_id)
+        assert result == {"Alice": 55.0, "Bob": 45.0}


### PR DESCRIPTION
## Summary

- Adds income source field for multiple sources per person (Løn, Børnepenge, etc.)
- Calculates proportional split percentages with manual override support
- Generates per-person, per-account transfer plan in whole kroner with rounding remainder to largest payer
- Dashboard shows transfer plan section when enabled; income page has toggle and percentage sliders

## Changes

- **New:** `src/db/split_store.py` — CRUD, percentage calculation, transfer plan generation
- **Schema:** `source` column on income, `income_split` table, `income_split_enabled` flag on users
- **Income page:** source field, split toggle, percentage sliders with auto-balance JS
- **Dashboard:** income distribution section with per-person transfers and unassigned expense note
- **Demo:** advanced mode showcases the feature with Børnepenge under Person 1
- **Tests:** 24 new tests covering split logic, integration, and edge cases (403 total, all pass)

## Test plan

- [ ] CI passes (403 tests)
- [ ] Login, add 2 persons with income, enable split toggle
- [ ] Verify sliders auto-balance to 100%
- [ ] Add accounts and assign expenses to accounts
- [ ] Verify dashboard shows transfer plan with correct amounts
- [ ] Toggle monthly/yearly on dashboard — transfer amounts update
- [ ] Verify demo-advanced shows income distribution section
- [ ] Test with single person — shows 100%
- [ ] Test rounding with odd amounts

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)