### PR TITLE
fix: migrate TemplateResponse to Starlette 1.0 + data loss warning

### DIFF
--- a/src/routes/accounts.py
+++ b/src/routes/accounts.py
@@ -28,10 +28,9 @@ async def accounts_page(request: Request, ctx: DataContext = Depends(get_data)):
     accounts = ctx.accounts()
     account_usage = ctx.account_usage()
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "accounts.html",
         {
-            "request": request,
             "accounts": accounts,
             "account_usage": account_usage,
             "demo_mode": ctx.demo,

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -31,7 +31,7 @@ async def login_page(request: Request):
     """Show login page."""
     if get_user_id(request) is not None:
         return RedirectResponse(url="/budget/", status_code=303)
-    return templates.TemplateResponse("login.html", {"request": request})
+    return templates.TemplateResponse(request, "login.html")
 
 
 @router.post("/login")
@@ -60,9 +60,9 @@ async def login(
         )
         return response
     else:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "login.html",
-            {"request": request, "error": "Forkert brugernavn eller adgangskode"}
+            {"error": "Forkert brugernavn eller adgangskode"}
         )
 
 
@@ -71,7 +71,7 @@ async def register_page(request: Request):
     """Show registration page."""
     if get_user_id(request) is not None:
         return RedirectResponse(url="/budget/", status_code=303)
-    return templates.TemplateResponse("register.html", {"request": request})
+    return templates.TemplateResponse(request, "register.html")
 
 
 @router.post("/register")
@@ -84,29 +84,29 @@ async def register(  # noqa: PLR0911
     """Register a new user."""
     # Validate input
     if len(username) < MIN_USERNAME_LENGTH:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "register.html",
-            {"request": request, "error": f"Brugernavn skal være mindst {MIN_USERNAME_LENGTH} tegn"}
+            {"error": f"Brugernavn skal være mindst {MIN_USERNAME_LENGTH} tegn"}
         )
 
     if len(password) < MIN_PASSWORD_LENGTH:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "register.html",
-            {"request": request, "error": f"Adgangskode skal være mindst {MIN_PASSWORD_LENGTH} tegn"}
+            {"error": f"Adgangskode skal være mindst {MIN_PASSWORD_LENGTH} tegn"}
         )
 
     if password != password_confirm:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "register.html",
-            {"request": request, "error": "Adgangskoderne matcher ikke"}
+            {"error": "Adgangskoderne matcher ikke"}
         )
 
     # Create user
     new_user_id = db.create_user(username, password)
     if new_user_id is None:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "register.html",
-            {"request": request, "error": "Brugernavnet er allerede taget"}
+            {"error": "Brugernavnet er allerede taget"}
         )
 
     # Auto-login after registration

--- a/src/routes/categories.py
+++ b/src/routes/categories.py
@@ -26,10 +26,9 @@ async def categories_page(request: Request, ctx: DataContext = Depends(get_data)
     categories = ctx.categories()
     category_usage = ctx.category_usage()
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "categories.html",
         {
-            "request": request,
             "categories": categories,
             "category_usage": category_usage,
             "demo_mode": ctx.demo,

--- a/src/routes/dashboard.py
+++ b/src/routes/dashboard.py
@@ -30,10 +30,9 @@ async def dashboard(request: Request, ctx: DataContext = Depends(get_data)):
         for cat, total in category_totals.items():
             category_percentages[cat] = (total / total_expenses) * 100
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "dashboard.html",
         {
-            "request": request,
             "incomes": incomes,
             "total_income": total_income,
             "total_expenses": total_expenses,

--- a/src/routes/expenses.py
+++ b/src/routes/expenses.py
@@ -46,10 +46,9 @@ async def expenses_page(request: Request, ctx: DataContext = Depends(get_data)):
     category_usage = ctx.category_usage()
     accounts = ctx.accounts()
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "expenses.html",
         {
-            "request": request,
             "expenses": expenses,
             "expenses_by_category": expenses_by_category,
             "category_totals": category_totals,

--- a/src/routes/income.py
+++ b/src/routes/income.py
@@ -25,9 +25,9 @@ async def income_page(request: Request, ctx: DataContext = Depends(get_data)):
     """Income edit page."""
     incomes = ctx.income()
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "income.html",
-        {"request": request, "incomes": incomes, "demo_mode": ctx.demo, "demo_advanced": ctx.advanced}
+        {"incomes": incomes, "demo_mode": ctx.demo, "demo_advanced": ctx.advanced}
     )
 
 

--- a/src/routes/pages.py
+++ b/src/routes/pages.py
@@ -32,10 +32,9 @@ async def about_page(request: Request):
     """About page with user guide and self-hosting info."""
     logged_in = check_auth(request)
     demo_mode = is_demo_mode(request)
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "om.html",
         {
-            "request": request,
             "demo_mode": demo_mode,
             "demo_advanced": is_demo_advanced(request),
             "show_nav": logged_in or demo_mode,
@@ -57,9 +56,9 @@ async def help_redirect(request: Request):
 @router.get("/privacy", response_class=HTMLResponse)
 async def privacy_page(request: Request):
     """Privacy policy page - accessible without login."""
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "privacy.html",
-        {"request": request, "show_nav": False}
+        {"show_nav": False}
     )
 
 
@@ -96,9 +95,9 @@ def record_feedback_attempt(client_ip: str):
 @router.get("/feedback", response_class=HTMLResponse)
 async def feedback_page(request: Request, _: None = Depends(require_auth)):
     """Feedback submission page."""
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "feedback.html",
-        {"request": request, "demo_mode": is_demo_mode(request), "demo_advanced": is_demo_advanced(request)}
+        {"demo_mode": is_demo_mode(request), "demo_advanced": is_demo_advanced(request)}
     )
 
 
@@ -119,17 +118,16 @@ async def submit_feedback(  # noqa: PLR0911, PLR0912
     if website:
         logger.warning(f"Honeypot triggered from {client_ip}")
         # Pretend success to fool bots
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "feedback.html",
-            {"request": request, "success": True, "demo_mode": demo, "demo_advanced": is_demo_advanced(request)}
+            {"success": True, "demo_mode": demo, "demo_advanced": is_demo_advanced(request)}
         )
 
     # Rate limiting
     if not check_feedback_rate_limit(client_ip):
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "feedback.html",
             {
-                "request": request,
                 "error": "For mange henvendelser. Prøv igen senere.",
                 "demo_mode": demo,
                 "demo_advanced": is_demo_advanced(request),
@@ -138,10 +136,9 @@ async def submit_feedback(  # noqa: PLR0911, PLR0912
 
     # Validate input
     if len(description.strip()) < 10:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "feedback.html",
             {
-                "request": request,
                 "error": "Beskrivelsen skal være mindst 10 tegn.",
                 "demo_mode": demo,
                 "demo_advanced": is_demo_advanced(request),
@@ -181,10 +178,9 @@ async def submit_feedback(  # noqa: PLR0911, PLR0912
                     raise Exception("feedback-api error")
         except Exception as e:
             logger.error(f"Failed to send feedback: {e}")
-            return templates.TemplateResponse(
+            return templates.TemplateResponse(request,
                 "feedback.html",
                 {
-                    "request": request,
                     "error": "Kunne ikke sende feedback. Prøv igen senere.",
                     "demo_mode": demo,
                     "demo_advanced": is_demo_advanced(request),
@@ -196,7 +192,7 @@ async def submit_feedback(  # noqa: PLR0911, PLR0912
 
     record_feedback_attempt(client_ip)
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "feedback.html",
-        {"request": request, "success": True, "demo_mode": demo, "demo_advanced": is_demo_advanced(request)}
+        {"success": True, "demo_mode": demo, "demo_advanced": is_demo_advanced(request)}
     )

--- a/src/routes/password_reset.py
+++ b/src/routes/password_reset.py
@@ -98,7 +98,7 @@ async def forgot_password_page(request: Request):
     """Show forgot password page."""
     if get_user_id(request) is not None:
         return RedirectResponse(url="/budget/", status_code=303)
-    return templates.TemplateResponse("forgot-password.html", {"request": request})
+    return templates.TemplateResponse(request, "forgot-password.html")
 
 
 @router.post("/forgot-password")
@@ -128,9 +128,9 @@ async def forgot_password(request: Request, email: str = Form(...)):
         # Send email
         send_password_reset_email(email, reset_url)
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "forgot-password.html",
-        {"request": request, "success": success_message}
+        {"success": success_message}
     )
 
 
@@ -142,14 +142,14 @@ async def reset_password_page(request: Request, token: str):
     reset_token = db.get_valid_reset_token(token_hash)
 
     if not reset_token:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "reset-password.html",
-            {"request": request, "invalid_token": "Dette link er ugyldigt eller udløbet. Anmod om et nyt link."}
+            {"invalid_token": "Dette link er ugyldigt eller udløbet. Anmod om et nyt link."}
         )
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "reset-password.html",
-        {"request": request, "token": token}
+        {"token": token}
     )
 
 
@@ -166,22 +166,22 @@ async def reset_password(
     reset_token = db.get_valid_reset_token(token_hash)
 
     if not reset_token:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "reset-password.html",
-            {"request": request, "invalid_token": "Dette link er ugyldigt eller udløbet. Anmod om et nyt link."}
+            {"invalid_token": "Dette link er ugyldigt eller udløbet. Anmod om et nyt link."}
         )
 
     # Validate password
     if len(password) < 6:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "reset-password.html",
-            {"request": request, "token": token, "error": "Adgangskoden skal være mindst 6 tegn"}
+            {"token": token, "error": "Adgangskoden skal være mindst 6 tegn"}
         )
 
     if password != password_confirm:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "reset-password.html",
-            {"request": request, "token": token, "error": "Adgangskoderne matcher ikke"}
+            {"token": token, "error": "Adgangskoderne matcher ikke"}
         )
 
     # Update password
@@ -190,7 +190,7 @@ async def reset_password(
     # Mark token as used
     db.mark_reset_token_used(reset_token.id)
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "reset-password.html",
-        {"request": request, "success": "Din adgangskode er blevet nulstillet. Du kan nu logge ind."}
+        {"success": "Din adgangskode er blevet nulstillet. Du kan nu logge ind."}
     )

--- a/src/routes/settings.py
+++ b/src/routes/settings.py
@@ -19,10 +19,9 @@ async def settings_page(request: Request, _: None = Depends(require_write("/budg
     user_id = get_user_id(request)
     user = db.get_user_by_id(user_id)
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "settings.html",
         {
-            "request": request,
             "username": user.username if user else "Ukendt",
             "has_email": user.has_email() if user else False
         }
@@ -47,10 +46,9 @@ async def update_email(  # noqa: PLR0911
     # If clearing email
     if not email:
         db.update_user_email(user_id, None)
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "settings.html",
             {
-                "request": request,
                 "username": user.username if user else "Ukendt",
                 "has_email": False,
                 "success": "Email fjernet"
@@ -59,10 +57,9 @@ async def update_email(  # noqa: PLR0911
 
     # Validate email format
     if "@" not in email:
-        return templates.TemplateResponse(
+        return templates.TemplateResponse(request,
             "settings.html",
             {
-                "request": request,
                 "username": user.username if user else "Ukendt",
                 "has_email": user.has_email() if user else False,
                 "error": "Ugyldig email-adresse"
@@ -72,10 +69,9 @@ async def update_email(  # noqa: PLR0911
     # Save email hash
     db.update_user_email(user_id, email)
 
-    return templates.TemplateResponse(
+    return templates.TemplateResponse(request,
         "settings.html",
         {
-            "request": request,
             "username": user.username if user else "Ukendt",
             "has_email": True,
             "success": "Email tilføjet"

--- a/src/routes/yearly.py
+++ b/src/routes/yearly.py
@@ -15,8 +15,7 @@ async def yearly_overview_page(request: Request, ctx: DataContext = Depends(get_
     """Yearly overview page with monthly expense breakdown."""
     overview = ctx.yearly_overview()
 
-    return templates.TemplateResponse("yearly.html", {
-        "request": request,
+    return templates.TemplateResponse(request, "yearly.html", {
         "overview": overview,
         "demo_mode": ctx.demo,
     })

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,6 +15,19 @@
             <p class="text-primary font-medium mt-2">Hold styr på familiens økonomi</p>
         </div>
 
+        <!-- Data loss warning -->
+        <div class="bg-amber-50 dark:bg-amber-900/30 border border-amber-300 dark:border-amber-700 rounded-xl px-4 py-4 mb-6 text-sm text-amber-800 dark:text-amber-300">
+            <div class="flex items-start gap-3">
+                <i data-lucide="triangle-alert" class="w-5 h-5 flex-shrink-0 mt-0.5"></i>
+                <div>
+                    <p class="font-semibold mb-1">Vigtig besked</p>
+                    <p>Så øøhm, alt er væk. Jeg fik ved et uheld ristet hele min server, inkl. databaser, backup og det hele... så alle brugere og deres oplysninger er væk. Så meget for selfhosted.</p>
+                    <p class="mt-2">Du skal være velkommen til at starte forfra, jeg er ved at bygge et system, så backup er placeret på en anden maskine her hjemme så det ikke sker igen.</p>
+                    <p class="mt-2">Beklager mange gange.<br>Vh Søren</p>
+                </div>
+            </div>
+        </div>
+
         <!-- Feature highlights -->
         <div class="mb-6 space-y-2">
             <div class="flex items-center gap-3 text-sm text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary
- **Starlette 1.0 fix**: All 32 `TemplateResponse` calls migrated from old `(name, context)` to new `(request, name, context)` signature. This fixes "unhashable type: dict" errors that broke every page after the Docker rebuild pulled Starlette 1.0.0.
- **Data loss warning**: Adds an amber warning banner on the login page informing users about the server wipe and that they need to create new accounts.

## Test plan
- [x] Login page loads without errors
- [x] Warning banner visible with correct text
- [ ] Other pages load correctly (dashboard, expenses, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)