### PR TITLE
Fix proxy-aware rate limiting and disable interactive docs in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ pip install uvicorn
 uvicorn src.api:app --host 0.0.0.0 --port 8086
 ```
 
+### Environment variables (deployment)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `ENVIRONMENT` | `production` | `development`/`dev`/`local` enables the interactive API docs (`/docs`, `/redoc`, `/openapi.json`). Anything else keeps them disabled. |
+| `TRUSTED_PROXY_IPS` | `127.0.0.1,::1` | Comma separated IPs/CIDRs whose `X-Forwarded-For` may be trusted. Rate limiting keys on the forwarded client address only for requests arriving from these proxies; headers from anywhere else are ignored. Set it to the reverse proxy's address (behind Docker, the bridge gateway, e.g. `172.17.0.1`). |
+
 ## Project Structure
 
 - `src/`: Backend logic and database operations.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     environment:
       - TZ=Europe/Copenhagen
       - PYTHONUNBUFFERED=1
+      # Production disables /docs, /redoc and /openapi.json
+      - ENVIRONMENT=${ENVIRONMENT:-production}
+      # Reverse proxies whose X-Forwarded-For may be trusted (Caddy on the
+      # Docker host reaches the container via the bridge gateway)
+      - TRUSTED_PROXY_IPS=${TRUSTED_PROXY_IPS:-127.0.0.1,::1,172.17.0.1}
       - APP_VERSION=${APP_VERSION}
       # Feedback API (replaces direct GitHub API calls)
       - FEEDBACK_API_URL=${FEEDBACK_API_URL:-http://172.17.0.1:3102}

--- a/src/api.py
+++ b/src/api.py
@@ -18,6 +18,7 @@ from .helpers import (  # noqa: F401 -- backward compat for tests
     hash_token,
     is_demo_advanced,
     is_demo_mode,
+    is_development,
     parse_danish_amount,
     save_sessions,
     templates,
@@ -31,9 +32,16 @@ db.init_db()
 logger = logging.getLogger(__name__)
 
 # Create app
+# Interactive API docs are development-only: a public financial app must not
+# publish /docs, /redoc or /openapi.json (ENVIRONMENT=development enables them).
+_DOCS_ENABLED = is_development()
+
 app = FastAPI(
     title="Family Budget",
     description="A simple family budget tracker",
+    docs_url="/docs" if _DOCS_ENABLED else None,
+    redoc_url="/redoc" if _DOCS_ENABLED else None,
+    openapi_url="/openapi.json" if _DOCS_ENABLED else None,
 )
 
 # Add security and rate limiting middleware

--- a/src/client_ip.py
+++ b/src/client_ip.py
@@ -1,0 +1,97 @@
+"""Client address resolution behind trusted reverse proxies.
+
+The app runs behind Caddy in production, so ``request.client.host`` is the
+proxy's address for every request. Rate limiting on that value collapses all
+users into a single bucket. We therefore read the forwarded header, but ONLY
+when the request actually arrives from a proxy we trust — an untrusted
+``X-Forwarded-For`` must never let a caller rotate identities.
+
+Configure with the ``TRUSTED_PROXY_IPS`` environment variable: a comma
+separated list of IP addresses or CIDR networks. Empty means "trust nobody".
+"""
+
+import ipaddress
+import logging
+import os
+
+from fastapi import Request
+
+logger = logging.getLogger(__name__)
+
+# Safe default: only the local loopback may present forwarded headers.
+DEFAULT_TRUSTED_PROXY_IPS = "127.0.0.1,::1"
+
+UNKNOWN_CLIENT = "unknown"
+
+
+def parse_trusted_proxies(raw: str | None) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Parse a comma separated list of IPs/CIDRs into networks.
+
+    Unparsable entries are ignored (and logged) rather than crashing startup.
+    """
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    for entry in (raw or "").split(","):
+        candidate = entry.strip()
+        if not candidate:
+            continue
+        try:
+            networks.append(ipaddress.ip_network(candidate, strict=False))
+        except ValueError:
+            logger.warning(f"Ignoring invalid TRUSTED_PROXY_IPS entry: {candidate!r}")
+    return networks
+
+
+def load_trusted_proxies() -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Read the trusted proxy set from the environment."""
+    return parse_trusted_proxies(os.getenv("TRUSTED_PROXY_IPS", DEFAULT_TRUSTED_PROXY_IPS))
+
+
+def _parse_address(value: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    candidate = value.strip()
+    if not candidate:
+        return None
+    # Strip an IPv6 bracket/port form such as "[::1]:443" and an IPv4 "host:port".
+    if candidate.startswith("["):
+        candidate = candidate[1:].split("]", 1)[0]
+    elif candidate.count(":") == 1:
+        candidate = candidate.split(":", 1)[0]
+    try:
+        return ipaddress.ip_address(candidate)
+    except ValueError:
+        return None
+
+
+def _is_trusted(address: str, trusted_proxies) -> bool:
+    parsed = _parse_address(address)
+    if parsed is None:
+        return False
+    return any(parsed in network for network in trusted_proxies)
+
+
+def get_client_ip(request: Request, trusted_proxies) -> str:
+    """Return the identity to key rate limiting on.
+
+    When the immediate peer is a trusted proxy, walk ``X-Forwarded-For`` from
+    right to left and return the first address that is not itself a trusted
+    proxy — that is the closest address the trusted chain actually vouches for.
+    Otherwise the peer address is used and the header is ignored entirely.
+    """
+    peer = request.client.host if request.client else None
+    if not peer:
+        return UNKNOWN_CLIENT
+
+    if not _is_trusted(peer, trusted_proxies):
+        # Not behind a proxy we trust: the header is attacker-controlled.
+        return peer
+
+    forwarded = request.headers.get("x-forwarded-for", "")
+    for hop in reversed(forwarded.split(",")):
+        parsed = _parse_address(hop)
+        if parsed is None:
+            continue
+        if any(parsed in network for network in trusted_proxies):
+            continue
+        return str(parsed)
+
+    # Trusted peer but no usable forwarded address — fall back to the peer.
+    return peer

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -13,6 +13,16 @@ from fastapi.templating import Jinja2Templates
 # Load environment
 load_dotenv(Path(__file__).parent.parent / ".env")
 
+# Deployment environment. Anything other than an explicit development value is
+# treated as production, so new deployments fail closed (no interactive docs).
+DEV_ENVIRONMENTS = {"development", "dev", "local"}
+
+
+def is_development() -> bool:
+    """True when the app runs in a development environment."""
+    return os.getenv("ENVIRONMENT", "production").strip().lower() in DEV_ENVIRONMENTS
+
+
 # Stripe donation payment links (override with env vars for production)
 DONATION_LINKS = {
     10: os.getenv("STRIPE_DONATE_10", "https://buy.stripe.com/test_28E14hdiw6eb5Z70Jl9IQ00"),

--- a/src/middleware.py
+++ b/src/middleware.py
@@ -7,22 +7,31 @@ from fastapi import Request
 from fastapi.responses import HTMLResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from .client_ip import get_client_ip, load_trusted_proxies
 from .constants import LOGIN_RATE_LIMIT_MAX, LOGIN_RATE_LIMIT_WINDOW
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
     """Simple rate limiting for login attempts."""
 
-    def __init__(self, app, max_attempts: int = LOGIN_RATE_LIMIT_MAX, window_seconds: int = LOGIN_RATE_LIMIT_WINDOW):
+    def __init__(
+        self,
+        app,
+        max_attempts: int = LOGIN_RATE_LIMIT_MAX,
+        window_seconds: int = LOGIN_RATE_LIMIT_WINDOW,
+        trusted_proxies=None,
+    ):
         super().__init__(app)
         self.max_attempts = max_attempts
         self.window_seconds = window_seconds
+        # Only these proxies may present a forwarded client address.
+        self.trusted_proxies = load_trusted_proxies() if trusted_proxies is None else trusted_proxies
         self.attempts: dict[str, list[float]] = defaultdict(list)
 
     async def dispatch(self, request: Request, call_next):
         # Only rate limit login POST requests
         if request.url.path == "/budget/login" and request.method == "POST":
-            client_ip = request.client.host if request.client else "unknown"
+            client_ip = get_client_ip(request, self.trusted_proxies)
             now = time.time()
 
             # Clean old attempts for this IP

--- a/src/routes/pages.py
+++ b/src/routes/pages.py
@@ -9,6 +9,7 @@ import httpx
 from fastapi import APIRouter, Depends, Form, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from ..client_ip import get_client_ip, load_trusted_proxies
 from ..dependencies import require_auth
 from ..helpers import (
     DONATION_LINKS,
@@ -75,6 +76,9 @@ feedback_attempts: dict[str, list[float]] = defaultdict(list)
 FEEDBACK_RATE_LIMIT = 5  # max submissions
 FEEDBACK_RATE_WINDOW = 3600  # per hour
 
+# Proxies whose forwarded client address may be trusted (see src/client_ip.py)
+TRUSTED_PROXIES = load_trusted_proxies()
+
 
 def check_feedback_rate_limit(client_ip: str) -> bool:
     """Check if client has exceeded feedback rate limit."""
@@ -102,7 +106,7 @@ async def feedback_page(request: Request, _: None = Depends(require_auth)):
 
 
 @router.post("/feedback")
-async def submit_feedback(  # noqa: PLR0911, PLR0912
+async def submit_feedback(  # noqa: PLR0911
     request: Request,
     feedback_type: str = Form(...),
     description: str = Form(...),
@@ -112,7 +116,7 @@ async def submit_feedback(  # noqa: PLR0911, PLR0912
 ):
     """Submit feedback via feedback-api."""
     demo = is_demo_mode(request)
-    client_ip = request.client.host if request.client else "unknown"
+    client_ip = get_client_ip(request, TRUSTED_PROXIES)
 
     # Honeypot check (bots fill hidden fields)
     if website:

--- a/tests/test_proxy_and_docs.py
+++ b/tests/test_proxy_and_docs.py
@@ -1,0 +1,172 @@
+"""Regression tests for reverse-proxy client identity and production docs.
+
+Covers the two pre-publication defects found before publishing the app behind
+Caddy: the login rate limiter collapsing into one global bucket, and FastAPI's
+interactive docs being served publicly.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from fastapi.testclient import TestClient
+
+from src.client_ip import (
+    DEFAULT_TRUSTED_PROXY_IPS,
+    get_client_ip,
+    load_trusted_proxies,
+    parse_trusted_proxies,
+)
+from src.helpers import is_development
+from src.middleware import RateLimitMiddleware
+
+LOOPBACK = parse_trusted_proxies("127.0.0.1,::1")
+
+
+class _FakeClient:
+    def __init__(self, host):
+        self.host = host
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette request."""
+
+    def __init__(self, peer, headers=None):
+        self.client = _FakeClient(peer) if peer else None
+        self.headers = {k.lower(): v for k, v in (headers or {}).items()}
+
+
+class TestParseTrustedProxies:
+    def test_default_is_loopback_only(self):
+        networks = parse_trusted_proxies(DEFAULT_TRUSTED_PROXY_IPS)
+        assert len(networks) == 2
+        assert str(networks[0]) == "127.0.0.1/32"
+
+    def test_empty_means_trust_nobody(self):
+        assert parse_trusted_proxies("") == []
+        assert parse_trusted_proxies(None) == []
+
+    def test_accepts_cidr_ranges(self):
+        networks = parse_trusted_proxies("10.0.0.0/8, 172.17.0.1")
+        assert str(networks[0]) == "10.0.0.0/8"
+        assert str(networks[1]) == "172.17.0.1/32"
+
+    def test_ignores_invalid_entries(self):
+        assert parse_trusted_proxies("not-an-ip, 127.0.0.1") == parse_trusted_proxies("127.0.0.1")
+
+    def test_loaded_from_environment(self, monkeypatch):
+        monkeypatch.setenv("TRUSTED_PROXY_IPS", "192.168.1.5")
+        assert str(load_trusted_proxies()[0]) == "192.168.1.5/32"
+
+    def test_environment_default_is_safe(self, monkeypatch):
+        monkeypatch.delenv("TRUSTED_PROXY_IPS", raising=False)
+        assert load_trusted_proxies() == parse_trusted_proxies(DEFAULT_TRUSTED_PROXY_IPS)
+
+
+class TestGetClientIp:
+    def test_uses_forwarded_header_from_trusted_proxy(self):
+        request = _FakeRequest("127.0.0.1", {"X-Forwarded-For": "203.0.113.7"})
+        assert get_client_ip(request, LOOPBACK) == "203.0.113.7"
+
+    def test_ignores_forwarded_header_from_untrusted_peer(self):
+        """A direct caller must not be able to spoof its identity."""
+        request = _FakeRequest("198.51.100.9", {"X-Forwarded-For": "203.0.113.7"})
+        assert get_client_ip(request, LOOPBACK) == "198.51.100.9"
+
+    def test_picks_closest_untrusted_hop(self):
+        request = _FakeRequest(
+            "127.0.0.1",
+            {"X-Forwarded-For": "203.0.113.7, 198.51.100.4, 127.0.0.1"},
+        )
+        assert get_client_ip(request, LOOPBACK) == "198.51.100.4"
+
+    def test_falls_back_to_peer_without_header(self):
+        assert get_client_ip(_FakeRequest("127.0.0.1"), LOOPBACK) == "127.0.0.1"
+
+    def test_falls_back_to_peer_on_garbage_header(self):
+        request = _FakeRequest("127.0.0.1", {"X-Forwarded-For": "not-an-ip"})
+        assert get_client_ip(request, LOOPBACK) == "127.0.0.1"
+
+    def test_handles_missing_client(self):
+        assert get_client_ip(_FakeRequest(None), LOOPBACK) == "unknown"
+
+    def test_no_trusted_proxies_ignores_header(self):
+        request = _FakeRequest("127.0.0.1", {"X-Forwarded-For": "203.0.113.7"})
+        assert get_client_ip(request, []) == "127.0.0.1"
+
+    def test_strips_port_from_forwarded_address(self):
+        request = _FakeRequest("127.0.0.1", {"X-Forwarded-For": "203.0.113.7:51234"})
+        assert get_client_ip(request, LOOPBACK) == "203.0.113.7"
+
+
+def _proxied_app(trusted_proxies):
+    """A tiny app with the real middleware, reachable as if through a proxy."""
+    app = FastAPI()
+    app.add_middleware(
+        RateLimitMiddleware,
+        max_attempts=5,
+        window_seconds=300,
+        trusted_proxies=trusted_proxies,
+    )
+
+    @app.post("/budget/login")
+    async def login():
+        return PlainTextResponse("ok")
+
+    # Present ourselves as connecting from a loopback proxy hop.
+    return TestClient(app, client=("127.0.0.1", 50000))
+
+
+class TestRateLimitBehindProxy:
+    """The client connects from 127.0.0.1, simulating a Caddy proxy hop."""
+
+    def test_two_clients_have_separate_buckets(self):
+        client = _proxied_app(parse_trusted_proxies("127.0.0.1"))
+
+        for _ in range(5):
+            assert client.post("/budget/login", headers={"X-Forwarded-For": "203.0.113.7"}).status_code == 200
+
+        # First client is now exhausted...
+        blocked = client.post("/budget/login", headers={"X-Forwarded-For": "203.0.113.7"})
+        assert blocked.status_code == 429
+        assert "For mange login forsøg" in blocked.text
+
+        # ...but a different real client must still be able to log in.
+        other = client.post("/budget/login", headers={"X-Forwarded-For": "198.51.100.4"})
+        assert other.status_code == 200
+
+    def test_spoofed_header_cannot_rotate_identity(self):
+        """From an untrusted peer the header is ignored, so the limit holds."""
+        client = _proxied_app(parse_trusted_proxies("10.99.99.99"))
+
+        for i in range(5):
+            response = client.post("/budget/login", headers={"X-Forwarded-For": f"203.0.113.{i}"})
+            assert response.status_code == 200
+
+        blocked = client.post("/budget/login", headers={"X-Forwarded-For": "203.0.113.200"})
+        assert blocked.status_code == 429
+
+
+class TestDocsDisabledInProduction:
+    @pytest.mark.parametrize("path", ["/docs", "/redoc", "/openapi.json"])
+    def test_docs_routes_absent(self, client, path):
+        """The app under test uses the production default (docs disabled)."""
+        assert client.get(path).status_code == 404
+
+    def test_app_has_no_docs_urls_configured(self):
+        from src.api import app
+        assert app.docs_url is None
+        assert app.redoc_url is None
+        assert app.openapi_url is None
+
+    def test_environment_defaults_to_production(self, monkeypatch):
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        assert is_development() is False
+
+    def test_production_value_is_not_development(self, monkeypatch):
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        assert is_development() is False
+
+    @pytest.mark.parametrize("value", ["development", "dev", "local", "DEVELOPMENT"])
+    def test_development_values_enable_docs(self, monkeypatch, value):
+        monkeypatch.setenv("ENVIRONMENT", value)
+        assert is_development() is True


### PR DESCRIPTION
Clears the two pre-publication defects found in the ingress/publication investigation (saabendtsen/homelab-workspace#170), before the app is served publicly behind Caddy.

## 1. Login rate limiting collapsed into one global bucket behind a proxy

`RateLimitMiddleware` keyed on `request.client.host`. Behind Caddy that is the proxy's address for every request, so all users shared a single bucket: per-client brute-force protection did not exist, and a single attacker failing 5 logins locked every real user out for 5 minutes.

New `src/client_ip.py` resolves the client identity:

- If the immediate peer is in the trusted proxy set, walk `X-Forwarded-For` right to left and use the closest hop that is not itself a trusted proxy.
- If the peer is **not** trusted, ignore the header entirely and key on the peer — a direct caller cannot rotate identities to bypass the limit.
- Fall back to the peer (or `unknown`) when the header is absent or unparsable.

Configured with `TRUSTED_PROXY_IPS` (comma separated IPs/CIDRs), defaulting to `127.0.0.1,::1` — loopback only, so it fails closed if nothing is configured. `docker-compose.yml` additionally names the Docker bridge gateway, where the host's Caddy reaches the container. The feedback rate limiter had the identical flaw and now uses the same resolution.

## 2. Interactive API docs enabled by default

`/docs`, `/redoc` and `/openapi.json` would have been publicly served. They are now development-only, via `ENVIRONMENT` (same env-var config style the app already uses), defaulting to `production` so any deployment that does not set it keeps them off.

## Tests

`tests/test_proxy_and_docs.py` (26 tests) covers header parsing, the trusted/untrusted decision, the spoofing case, and the docs routes being absent under production settings — including an end-to-end middleware check that two different clients through a simulated proxy hop get separate buckets while a spoofed header from an untrusted peer does not.

Full suite green locally: 412 unit/integration tests and 78 Playwright E2E tests.

No behaviour change for a direct (non-proxied) deployment.