### PR TITLE
docs: correct the TRUSTED_PROXY_IPS example address

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ uvicorn src.api:app --host 0.0.0.0 --port 8086
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `ENVIRONMENT` | `production` | `development`/`dev`/`local` enables the interactive API docs (`/docs`, `/redoc`, `/openapi.json`). Anything else keeps them disabled. |
-| `TRUSTED_PROXY_IPS` | `127.0.0.1,::1` | Comma separated IPs/CIDRs whose `X-Forwarded-For` may be trusted. Rate limiting keys on the forwarded client address only for requests arriving from these proxies; headers from anywhere else are ignored. Set it to the reverse proxy's address (behind Docker, the bridge gateway, e.g. `172.17.0.1`). |
+| `TRUSTED_PROXY_IPS` | `127.0.0.1,::1` | Comma separated IPs/CIDRs whose `X-Forwarded-For` may be trusted. Rate limiting keys on the forwarded client address only for requests arriving from these proxies; headers from anywhere else are ignored. Set it to the address the proxy's requests actually arrive from. Behind Docker this is a gateway address, but not necessarily the default bridge: if the proxy is host-networked and reaches a published port, requests re-originate from the Compose project network's gateway. Confirm it rather than assuming - `docker network inspect <project>_default` - and cross-check against the peer address in the container's request log. A wrong value fails closed: the header is ignored and every client shares one rate-limit bucket. |
 
 ## Project Structure
 


### PR DESCRIPTION
The README example pointed at the default Docker bridge gateway (`172.17.0.1`).

On `homelab` that is the wrong address: Caddy runs host-networked and proxies to a published port, so requests reach the container from the **Compose project network** gateway (verified live as `172.23.0.1` via `docker network inspect family-budget_default` and the container's own request log).

Because `TRUSTED_PROXY_IPS` fails closed, a wrong value is silent — the forwarded header is ignored and every client shares one rate-limit bucket, which is exactly the defect the setting was added to prevent. The README now tells the reader to confirm the address instead of assuming one, and says what a wrong value costs.

Docs only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017paqJpwhbMHfcckjhRxBCX